### PR TITLE
Add virtual time capability handling in glfw

### DIFF
--- a/source/examples/ViewerGLFW/main.cpp
+++ b/source/examples/ViewerGLFW/main.cpp
@@ -43,10 +43,10 @@ int main(int argc, char *argv[])
 
     // Create event handler
     WindowEventHandler * eventHandler = new WindowEventHandler();
-    eventHandler->setPainter(painter);
 
     // Create window
     Window window;
+    window.setPainter(painter);
     window.setEventHandler(eventHandler);
     if (window.create(format, "gloperate viewer")) {
         // Show window and run application

--- a/source/gloperate-glfw/include/gloperate-glfw/Window.h
+++ b/source/gloperate-glfw/include/gloperate-glfw/Window.h
@@ -9,6 +9,13 @@
 #include <gloperate-glfw/MainLoop.h>
 #include <gloperate-glfw/WindowEventHandlerBase.h>
 
+#include <globjects/base/ref_ptr.h>
+
+#include <gloperate/Painter.h>
+
+#include <gloperate-glfw/gloperate-glfw_api.h>
+#include <gloperate-glfw/Window.h>
+
 
 struct GLFWwindow;
 struct GLFWmonitor;
@@ -35,7 +42,7 @@ public:
     virtual ~Window();
 
     bool create(const ContextFormat & format, int width = 1280, int height = 720);
-    bool create(const ContextFormat & format, const std::string & title = "globjects", int width = 1280, int height = 720);
+    bool create(const ContextFormat & format, const std::string & title = "gloperate", int width = 1280, int height = 720);
 
     /**
      * Takes ownership of the given eventhandler and deletes that either on
@@ -99,7 +106,8 @@ public:
     void swap();
     void destroy();
 
-
+    gloperate::Painter * painter() const;
+    void setPainter(gloperate::Painter * painter);
 protected:
     bool createContext(const ContextFormat & format, int width, int height, GLFWmonitor* monitor = nullptr);
     void destroyContext();
@@ -130,7 +138,7 @@ protected:
 
     Mode m_mode;
 
-
+    globjects::ref_ptr<gloperate::Painter> m_painter;
 private:
     static std::set<Window*> s_instances;
 

--- a/source/gloperate-glfw/include/gloperate-glfw/WindowEventHandler.h
+++ b/source/gloperate-glfw/include/gloperate-glfw/WindowEventHandler.h
@@ -1,10 +1,6 @@
 #pragma once
 
-
-#include <globjects/base/ref_ptr.h>
-#include <gloperate/Painter.h>
 #include <gloperate-glfw/WindowEventHandlerBase.h>
-
 
 namespace gloperate_glfw
 {
@@ -12,30 +8,19 @@ namespace gloperate_glfw
 
 class GLOPERATE_GLFW_API WindowEventHandler : public WindowEventHandlerBase
 {
-
-
 public:
     WindowEventHandler();
     virtual ~WindowEventHandler();
 
-    gloperate::Painter * painter() const;
-    void setPainter(gloperate::Painter * painter);
-
     virtual void initialize(gloperate_glfw::Window & window) override;
-	virtual void idle(Window & window) override;
-
 
 protected:
     virtual void framebufferResizeEvent(ResizeEvent & event) override;
     virtual void paintEvent(PaintEvent & event) override;
     virtual void keyPressEvent(KeyEvent & event) override;
-
-
-protected:
-    globjects::ref_ptr<gloperate::Painter> m_painter;
+    virtual void timerEvent(TimerEvent & event) override;
 
 
 };
-
 
 } // namespace gloperate_glfw

--- a/source/gloperate-glfw/include/gloperate-glfw/events.h
+++ b/source/gloperate-glfw/include/gloperate-glfw/events.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <chrono>
 
 #include <gloperate-glfw/gloperate-glfw_api.h>
 #include <gloperate-glfw/keys.h>
+
 #include <glm/glm.hpp>
 
 
@@ -49,7 +51,7 @@ public:
     void ignore();
 
     Window* window() const;
-    void setWindow(Window* window);
+    void setWindow(Window *window);
 
 protected:
     WindowEvent(Type type);
@@ -191,12 +193,14 @@ protected:
 class GLOPERATE_GLFW_API TimerEvent : public WindowEvent
 {
 public:
-    TimerEvent(int id);
+    using Duration = std::chrono::duration<double, std::milli>;
+    TimerEvent(int id, const Duration & elapsed);
 
     int id() const;
+    const Duration & elapsed() const;
 protected:
     int m_id;
+    Duration m_elapsed;
 };
-
 
 } // namespace gloperate_glfw

--- a/source/gloperate-glfw/source/Window.cpp
+++ b/source/gloperate-glfw/source/Window.cpp
@@ -8,6 +8,8 @@
 #include <gloperate-glfw/events.h>
 #include <gloperate-glfw/WindowEventDispatcher.h>
 
+#include <gloperate/capabilities/AbstractVirtualTimeCapability.h>
+
 
 namespace gloperate_glfw
 {
@@ -463,6 +465,23 @@ void Window::addTimer(int id, int interval, bool singleShot)
 void Window::removeTimer(int id)
 {
     WindowEventDispatcher::removeTimer(this, id);
+}
+
+gloperate::Painter * Window::painter() const
+{
+    return m_painter;
+}
+
+void Window::setPainter(gloperate::Painter * painter)
+{
+    m_painter = painter;
+
+    gloperate::AbstractVirtualTimeCapability * timeCapability = m_painter->getCapability<gloperate::AbstractVirtualTimeCapability>();
+
+    if (timeCapability)
+    {
+        addTimer(0, 0, false);
+    }
 }
 
 

--- a/source/gloperate-glfw/source/WindowEventDispatcher.cpp
+++ b/source/gloperate-glfw/source/WindowEventDispatcher.cpp
@@ -131,7 +131,7 @@ void WindowEventDispatcher::checkForTimerEvents()
 
             if (timer.ready())
             {
-                dispatchEvent(window, new TimerEvent(id));
+                dispatchEvent(window, new TimerEvent(id, timer.elapsed));
                 if (timer.singleShot)
                 {
                     discarded.emplace_back(window, id);
@@ -150,7 +150,7 @@ void WindowEventDispatcher::checkForTimerEvents()
     }
 }
 
-Window* WindowEventDispatcher::fromGLFW(GLFWwindow* glfwWindow)
+Window *WindowEventDispatcher::fromGLFW(GLFWwindow* glfwWindow)
 {
     return glfwWindow ? static_cast<Window*>(glfwGetWindowUserPointer(glfwWindow)) : nullptr;
 }

--- a/source/gloperate-glfw/source/WindowEventHandler.cpp
+++ b/source/gloperate-glfw/source/WindowEventHandler.cpp
@@ -5,6 +5,9 @@
 #include <gloperate/Viewport.h>
 
 #include <gloperate/capabilities/AbstractViewportCapability.h>
+#include <gloperate/capabilities/AbstractVirtualTimeCapability.h>
+
+#include <gloperate-glfw/Window.h>
 
 using namespace gloperate;
 namespace gloperate_glfw
@@ -19,39 +22,23 @@ WindowEventHandler::~WindowEventHandler()
 {
 }
 
-Painter * WindowEventHandler::painter() const
-{
-    return m_painter;
-}
-
-void WindowEventHandler::setPainter(Painter * painter)
-{
-    m_painter = painter;
-}
-
-void WindowEventHandler::initialize(gloperate_glfw::Window & /*window*/)
+void WindowEventHandler::initialize(Window & window)
 {
     // Initialize globjects
     globjects::init();
     IF_DEBUG(globjects::DebugMessage::enable(true);)
 
     // Initialize painter
-    if (m_painter) {
-        m_painter->initialize();
+    if (window.painter()) {
+        window.painter()->initialize();
     }
-}
-
-void WindowEventHandler::idle(Window & window)
-{
-    // Continuous repaint
-    window.repaint();
 }
 
 void WindowEventHandler::framebufferResizeEvent(ResizeEvent & event)
 {
-    if (m_painter) {
+    if (event.window()->painter()) {
         // Resize painter
-        AbstractViewportCapability * viewportCapability = m_painter->getCapability<AbstractViewportCapability>();
+        AbstractViewportCapability * viewportCapability = event.window()->painter()->getCapability<AbstractViewportCapability>();
 
         if (viewportCapability)
         {
@@ -61,16 +48,30 @@ void WindowEventHandler::framebufferResizeEvent(ResizeEvent & event)
     }
 }
 
-void WindowEventHandler::paintEvent(PaintEvent & /*event*/)
+void WindowEventHandler::paintEvent(PaintEvent & event)
 {
-    if (m_painter) {
+    if (event.window()->painter()) {
         // Call painter
-        m_painter->paint();
+        event.window()->painter()->paint();
     }
 }
 
 void WindowEventHandler::keyPressEvent(KeyEvent & /*event*/)
 {
+}
+
+void WindowEventHandler::timerEvent(TimerEvent & event)
+{
+    if (event.window()->painter())
+    {
+        AbstractVirtualTimeCapability * timeCapability = event.window()->painter()->getCapability<AbstractVirtualTimeCapability>();
+
+        if (timeCapability)
+        {
+            timeCapability->update(std::chrono::duration_cast<std::chrono::duration<float>>(event.elapsed()).count());
+            event.window()->repaint();
+        }
+    }
 }
 
 

--- a/source/gloperate-glfw/source/events.cpp
+++ b/source/gloperate-glfw/source/events.cpp
@@ -52,7 +52,7 @@ Window* WindowEvent::window() const
     return m_window;
 }
 
-void WindowEvent::setWindow(Window* window)
+void WindowEvent::setWindow(Window *window)
 {
     m_window = window;
 }
@@ -254,15 +254,21 @@ bool IconifyEvent::isIconified() const
     return m_isIconified;
 }
 
-TimerEvent::TimerEvent(int id)
+TimerEvent::TimerEvent(int id, const Duration & elapsed)
 : WindowEvent(Timer)
 , m_id(id)
+, m_elapsed(elapsed)
 {
 }
 
 int TimerEvent::id() const
 {
     return m_id;
+}
+
+const TimerEvent::Duration & TimerEvent::elapsed() const
+{
+    return m_elapsed;
 }
 
 


### PR DESCRIPTION
Additionally move `painter` member to `Window`, since a `WindowEventHandler` can operate on multiple windows simultaneously.
