### PR TITLE
MSVC12 compile fixes & small plugin restructuring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,10 @@ project(${META_PROJECT_NAME} C CXX)
 
 # Configuration options
 
-option(OPTION_PORTABLE_INSTALL    "Install to a local directory instead of the system" OFF)
-option(OPTION_BUILD_STATIC        "Build static libraries" OFF)
-option(OPTION_BUILD_TESTS         "Build tests (if gmock and gtest are found)" ON)
-option(OPTION_BUILD_EXAMPLES      "Build examples (requires optional module glfw)" OFF)
+option(OPTION_PORTABLE_INSTALL  "Install to a local directory instead of the system" OFF)
+option(OPTION_BUILD_STATIC      "Build static libraries" OFF)
+option(OPTION_BUILD_TESTS       "Build tests (if gmock and gtest are found)" ON)
+option(OPTION_BUILD_EXAMPLES    "Build examples (requires optional module glfw)" OFF)
 
 
 if(OPTION_BUILD_STATIC)

--- a/source/examples/CMakeLists.txt
+++ b/source/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 if(OPTION_BUILD_EXAMPLES)
-
+	set(INSTALL_PLUGINS       	${INSTALL_BIN}/plugins)
+	set(INSTALL_PLUGINS_DEBUG	${INSTALL_BIN}/plugins/debug)
+	
     # Example plugins
     add_subdirectory(basic-painters)
     add_subdirectory(pipeline-painters)

--- a/source/examples/basic-painters/CMakeLists.txt
+++ b/source/examples/basic-painters/CMakeLists.txt
@@ -98,9 +98,14 @@ set_target_properties(${target}
 
 # Library
 install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_BIN}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS} CONFIGURATIONS Release
     LIBRARY DESTINATION ${INSTALL_SHARED}
     ARCHIVE DESTINATION ${INSTALL_LIB}
+)
+
+# Debug runtime library
+install(TARGETS ${target}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
 )
 
 # Header files

--- a/source/examples/extended-painters/CMakeLists.txt
+++ b/source/examples/extended-painters/CMakeLists.txt
@@ -105,9 +105,14 @@ set_target_properties(${target}
 
 # Library
 install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_BIN}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS} CONFIGURATIONS Release
     LIBRARY DESTINATION ${INSTALL_SHARED}
     ARCHIVE DESTINATION ${INSTALL_LIB}
+)
+
+# Debug runtime library
+install(TARGETS ${target}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
 )
 
 # Header files

--- a/source/examples/osg-painters/CMakeLists.txt
+++ b/source/examples/osg-painters/CMakeLists.txt
@@ -105,9 +105,14 @@ set_target_properties(${target}
 
 # Library
 install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_BIN}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS} CONFIGURATIONS Release
     LIBRARY DESTINATION ${INSTALL_SHARED}
     ARCHIVE DESTINATION ${INSTALL_LIB}
+)
+
+# Debug runtime library
+install(TARGETS ${target}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
 )
 
 # Header files

--- a/source/examples/pipeline-painters/CMakeLists.txt
+++ b/source/examples/pipeline-painters/CMakeLists.txt
@@ -95,9 +95,14 @@ set_target_properties(${target}
 
 # Library
 install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_BIN}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS} CONFIGURATIONS Release
     LIBRARY DESTINATION ${INSTALL_SHARED}
     ARCHIVE DESTINATION ${INSTALL_LIB}
+)
+
+# Debug runtime library
+install(TARGETS ${target}
+    RUNTIME DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
 )
 
 # Header files

--- a/source/gloperate-osg/include/gloperate-osg/OsgKeyboardHandler.h
+++ b/source/gloperate-osg/include/gloperate-osg/OsgKeyboardHandler.h
@@ -10,11 +10,7 @@
 #include <gloperate/input/KeyboardInputHandler.h>
 #include <gloperate-osg/gloperate-osg_api.h>
 #include <osg/ref_ptr>
-
-
-namespace osgViewer {
-    class GraphicsWindowEmbedded;
-}
+#include <osgViewer/GraphicsWindow>
 
 
 namespace gloperate_osg


### PR DESCRIPTION
- Fixed a little compile error in _plugin.cpp_ of **osg-painters example** ( introduced with 9f4a257dc439e8c93b52d8248f417834c151fef4 )
- included _osgViewer::GraphicsWindowEmbedded_ Header to fix incomplete type compile error
- ~~put the plugins in seperate subfolder in examples~~ & installs plugin runtime libs in subfolder "plugins" of bin dir (to get consistency between viewer-qt and viewer-qt-extended in which such structure was demanded)
