### PR TITLE
Fixes Compile errors

### DIFF
--- a/source/gloperate-qtwidgets/CMakeLists.txt
+++ b/source/gloperate-qtwidgets/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/source
     ${CMAKE_SOURCE_DIR}/source/gloperate/include
+    ${CMAKE_SOURCE_DIR}/source/gloperate-qt/include
 )
 
 

--- a/source/gloperate-qtwidgets/source/ScreenshotWidget.cpp
+++ b/source/gloperate-qtwidgets/source/ScreenshotWidget.cpp
@@ -15,8 +15,8 @@ namespace gloperate_qtwidgets
 
 ScreenshotWidget::ScreenshotWidget(gloperate::ResourceManager & resourceManager, gloperate::Painter * painter, gloperate_qt::QtOpenGLWindow * context, QWidget *parent)
 :	QWidget(parent)
-,	m_ui(new Ui_ScreenshotWidget)
 ,	m_context(context)
+,	m_ui(new Ui_ScreenshotWidget)
 {
 	m_ui->setupUi(this);
 


### PR DESCRIPTION
- missing include (because of missing include directory link in cmake)
- wrong initialization order (causes compile error on my gcc 4.8.3
  linux machine)
