### PR TITLE
Fixes cmake policy CMP0028 (Qt5::OpenGL missing)

### DIFF
--- a/source/gloperate-qtwidgets/CMakeLists.txt
+++ b/source/gloperate-qtwidgets/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 find_package(Qt5Core    5.1 REQUIRED)
 find_package(Qt5Gui     5.1 REQUIRED)
 find_package(Qt5Widgets 5.1 REQUIRED) # this is also important in order to get uic working
+find_package(Qt5OpenGL  5.1 REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 set(AUTOMOC_MOC_OPTIONS PROPERTIES FOLDER CMakeAutomocTargets)
@@ -95,7 +96,7 @@ qt5_wrap_ui(uihs ${uis})
 
 add_library(${target} ${api_includes} ${sources})
 
-qt5_use_modules(${target} Core Gui Widgets)
+qt5_use_modules(${target} Core Gui Widgets OpenGL)
 target_link_libraries(${target} ${libs})
 
 # qt fix - 4244 -> 'argument' : conversion from 'type1' to 'type2', possible loss of data


### PR DESCRIPTION
with cmake 3.0.2

CMake Warning (dev) at source/gloperate-qtwidgets/CMakeLists.txt:97 (add_library):
  Policy CMP0028 is not set: Double colon in target name means ALIAS or
  IMPORTED target.  Run "cmake --help-policy CMP0028" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  Target "gloperate-qtwidgets" links to target "Qt5::OpenGL" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
This warning is for project developers.  Use -Wno-dev to suppress it.
