### PR TITLE
Removes install for example helper libraries

### DIFF
--- a/source/examples/globjects-painters/CMakeLists.txt
+++ b/source/examples/globjects-painters/CMakeLists.txt
@@ -88,22 +88,3 @@ set_target_properties(${target}
     LINK_FLAGS_RELEASE          "${DEFAULT_LINKER_FLAGS_RELEASE}"
     DEBUG_POSTFIX               "d${DEBUG_POSTFIX}"
     INCLUDE_PATH                ${include_path})
-
-
-# Deployment
-
-# Plugin library (release)
-install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_PLUGINS}       CONFIGURATIONS Release
-    LIBRARY DESTINATION ${INSTALL_PLUGINS}       CONFIGURATIONS Release
-    ARCHIVE DESTINATION ${INSTALL_LIB}
-)
-
-# Plugin library (debug)
-install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
-    LIBRARY DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
-)
-
-# Header files
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/${target} DESTINATION ${INSTALL_INCLUDE})

--- a/source/examples/osg-painters/CMakeLists.txt
+++ b/source/examples/osg-painters/CMakeLists.txt
@@ -93,22 +93,3 @@ set_target_properties(${target}
     LINK_FLAGS_RELEASE          "${DEFAULT_LINKER_FLAGS_RELEASE}"
     DEBUG_POSTFIX               "d${DEBUG_POSTFIX}"
     INCLUDE_PATH                ${include_path})
-
-
-# Deployment
-
-# Plugin library (release)
-install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_PLUGINS}       CONFIGURATIONS Release
-    LIBRARY DESTINATION ${INSTALL_PLUGINS}       CONFIGURATIONS Release
-    ARCHIVE DESTINATION ${INSTALL_LIB}
-)
-
-# Plugin library (debug)
-install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
-    LIBRARY DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
-)
-
-# Header files
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/${target} DESTINATION ${INSTALL_INCLUDE})

--- a/source/examples/pipeline-painters/CMakeLists.txt
+++ b/source/examples/pipeline-painters/CMakeLists.txt
@@ -83,22 +83,3 @@ set_target_properties(${target}
     LINK_FLAGS_RELEASE          "${DEFAULT_LINKER_FLAGS_RELEASE}"
     DEBUG_POSTFIX               "d${DEBUG_POSTFIX}"
     INCLUDE_PATH                ${include_path})
-
-
-# Deployment
-
-# Plugin library (release)
-install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_PLUGINS}       CONFIGURATIONS Release
-    LIBRARY DESTINATION ${INSTALL_PLUGINS}       CONFIGURATIONS Release
-    ARCHIVE DESTINATION ${INSTALL_LIB}
-)
-
-# Plugin library (debug)
-install(TARGETS ${target}
-    RUNTIME DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
-    LIBRARY DESTINATION ${INSTALL_PLUGINS_DEBUG} CONFIGURATIONS Debug
-)
-
-# Header files
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/${target} DESTINATION ${INSTALL_INCLUDE})


### PR DESCRIPTION
The libraries used to aid the example applications shouldn't be installed, should they?

-- Up-to-date: /usr/local/share/gloperate/examples/plugins/debug/libglobjects-paintersd.so
CMake Error at source/examples/globjects-painters/cmake_install.cmake:76 (file):
  file INSTALL cannot find
  "[...]/gloperate/source/examples/globjects-painters/include/globjects-painters".
Call Stack (most recent call first):
  source/examples/cmake_install.cmake:37 (include)
  source/cmake_install.cmake:42 (include)
  cmake_install.cmake:53 (include)

Makefile:69: recipe for target 'install' failed
make: **\* [install] Error 1
