### PR TITLE
Add DevicePixelRatioCapability

### DIFF
--- a/source/gloperate-qt/include/gloperate-qt/QtOpenGLWindow.h
+++ b/source/gloperate-qt/include/gloperate-qt/QtOpenGLWindow.h
@@ -1,5 +1,5 @@
-#pragma once
 
+#pragma once
 
 #include <QScopedPointer>
 
@@ -28,8 +28,6 @@ namespace gloperate_qt
 */
 class GLOPERATE_QT_API QtOpenGLWindow : public QtOpenGLWindowBase
 {
-
-
 public:
     /**
     *  @brief
@@ -83,13 +81,13 @@ protected:
     virtual void mouseDoubleClickEvent(QMouseEvent * event) override;
     virtual void wheelEvent(QWheelEvent * event) override;
 
+    void setViewport(int width, int height);
+
 
 protected:
     gloperate::ResourceManager & m_resourceManager;
-    gloperate::Painter * m_painter;          /**< Currently used painter */
-    QScopedPointer<TimePropagator>         m_timePropagator;  /**< Time propagator for continous updates */
-
-
+    gloperate::Painter * m_painter;                  /**< Currently used painter */
+    QScopedPointer<TimePropagator> m_timePropagator; /**< Time propagator for continous updates */
 };
 
 

--- a/source/gloperate-qt/source/QtOpenGLWindow.cpp
+++ b/source/gloperate-qt/source/QtOpenGLWindow.cpp
@@ -14,8 +14,9 @@
 
 #include <globjects/globjects.h>
 
-#include <gloperate/painter/AbstractViewportCapability.h>
+#include <gloperate/painter/AbstractDevicePixelRatioCapability.h>
 #include <gloperate/painter/AbstractInputCapability.h>
+#include <gloperate/painter/AbstractViewportCapability.h>
 #include <gloperate/resources/ResourceManager.h>
 #include <gloperate/tools/ScreenshotTool.h>
 
@@ -102,14 +103,7 @@ void QtOpenGLWindow::onInitialize()
     // Initialize painter
     if (m_painter)
     {
-        AbstractViewportCapability * viewportCapability = m_painter->getCapability<AbstractViewportCapability>();
-
-        if (viewportCapability)
-        {
-            qreal factor = QWindow::devicePixelRatio();
-            // Resize painter
-            viewportCapability->setViewport(0, 0, factor * width(), factor * height());
-        }
+        setViewport(width(), height());
 
         m_painter->initialize();
     }
@@ -119,13 +113,7 @@ void QtOpenGLWindow::onResize(QResizeEvent * event)
 {
     if (m_painter)
     {
-        // Check if the painter supports the viewport capability
-        AbstractViewportCapability * viewportCapability = m_painter->getCapability<AbstractViewportCapability>();
-        if (viewportCapability)
-        {
-            // Resize painter
-            viewportCapability->setViewport(0, 0, event->size().width(), event->size().height());
-        }
+        setViewport(event->size().width(), event->size().height());
     }
 }
 
@@ -249,6 +237,28 @@ void QtOpenGLWindow::wheelEvent(QWheelEvent * event)
             event->orientation() == Qt::Vertical ? 0 : event->delta(),
             event->orientation() == Qt::Vertical ? event->delta() : 0
         );
+    }
+}
+
+void QtOpenGLWindow::setViewport(int width, int height)
+{
+    auto viewportCapability = m_painter->getCapability<AbstractViewportCapability>();
+
+    if (viewportCapability)
+    {
+        qreal factor = QWindow::devicePixelRatio();
+
+        auto devicePixelRatioCapability = m_painter->getCapability<AbstractDevicePixelRatioCapability>();
+
+        if (devicePixelRatioCapability)
+        {
+            devicePixelRatioCapability->setDevicePixelRatio(factor);
+            viewportCapability->setViewport(0, 0, width, height);
+        }
+        else
+        {
+            viewportCapability->setViewport(0, 0, factor * width, factor * height);
+        }
     }
 }
 

--- a/source/gloperate-qt/source/QtOpenGLWindowBase.cpp
+++ b/source/gloperate-qt/source/QtOpenGLWindowBase.cpp
@@ -114,7 +114,7 @@ void QtOpenGLWindowBase::resize(QResizeEvent * event)
 
     m_context->makeCurrent(this);
 
-    QResizeEvent deviceSpecificResizeEvent(event->size() * devicePixelRatio(), event->oldSize() * devicePixelRatio());
+    QResizeEvent deviceSpecificResizeEvent(event->size(), event->oldSize());
 
     onResize(&deviceSpecificResizeEvent);
 

--- a/source/gloperate/CMakeLists.txt
+++ b/source/gloperate/CMakeLists.txt
@@ -77,32 +77,34 @@ set(sources
     ${source_path}/navigation/navigationmath.cpp
     ${source_path}/navigation/WorldInHandNavigation.cpp
     
-    ${source_path}/painter/PerspectiveProjectionCapability.cpp
-    ${source_path}/painter/TargetFramebufferCapability.cpp
-    ${source_path}/painter/CameraCapability.cpp
-    ${source_path}/painter/TypedRenderTargetCapability.cpp
-    ${source_path}/painter/Painter.cpp
-    ${source_path}/painter/AbstractVirtualTimeCapability.cpp
-    ${source_path}/painter/ViewportCapability.cpp
-    ${source_path}/painter/AbstractInputCapability.cpp
-    ${source_path}/painter/AbstractProjectionCapability.cpp
-    ${source_path}/painter/Camera.cpp
-    ${source_path}/painter/ContextFormat.cpp
     ${source_path}/painter/AbstractCameraCapability.cpp
-    ${source_path}/painter/AbstractPerspectiveProjectionCapability.cpp
     ${source_path}/painter/AbstractCapability.cpp
-    ${source_path}/painter/InputCapability.cpp
-    ${source_path}/painter/AbstractTypedRenderTargetCapability.cpp
-    ${source_path}/painter/VirtualTimeCapability.cpp
     ${source_path}/painter/AbstractContext.cpp
-    ${source_path}/painter/AbstractTargetFramebufferCapability.cpp
-    ${source_path}/painter/AbstractViewportCapability.cpp
+    ${source_path}/painter/AbstractDevicePixelRatioCapability.cpp
+    ${source_path}/painter/AbstractInputCapability.cpp
     ${source_path}/painter/AbstractMetaInformationCapability.cpp
-    ${source_path}/painter/MetaInformationCapability.cpp
-    ${source_path}/painter/AbstractOutputCapability.cpp
-    ${source_path}/painter/PipelineOutputCapability.cpp
     ${source_path}/painter/AbstractOrthographicProjectionCapability.cpp
+    ${source_path}/painter/AbstractOutputCapability.cpp
+    ${source_path}/painter/AbstractPerspectiveProjectionCapability.cpp
+    ${source_path}/painter/AbstractProjectionCapability.cpp
+    ${source_path}/painter/AbstractTargetFramebufferCapability.cpp
+    ${source_path}/painter/AbstractTypedRenderTargetCapability.cpp
+    ${source_path}/painter/AbstractViewportCapability.cpp
+    ${source_path}/painter/AbstractVirtualTimeCapability.cpp
+    ${source_path}/painter/Camera.cpp
+    ${source_path}/painter/CameraCapability.cpp
+    ${source_path}/painter/ContextFormat.cpp
+    ${source_path}/painter/DevicePixelRatioCapability.cpp
+    ${source_path}/painter/InputCapability.cpp
+    ${source_path}/painter/MetaInformationCapability.cpp
     ${source_path}/painter/OrthographicProjectionCapability.cpp
+    ${source_path}/painter/Painter.cpp
+    ${source_path}/painter/PerspectiveProjectionCapability.cpp
+    ${source_path}/painter/PipelineOutputCapability.cpp
+    ${source_path}/painter/TargetFramebufferCapability.cpp
+    ${source_path}/painter/TypedRenderTargetCapability.cpp
+    ${source_path}/painter/ViewportCapability.cpp
+    ${source_path}/painter/VirtualTimeCapability.cpp
     
     ${source_path}/pipeline/AbstractInputSlot.cpp
     ${source_path}/pipeline/InputSlot.cpp
@@ -164,35 +166,37 @@ set(api_includes
     ${include_path}/navigation/AbstractMapping.h
     ${include_path}/navigation/navigationmath.h
     
-    ${include_path}/painter/InputCapability.h
-    ${include_path}/painter/AbstractInputCapability.h
-    ${include_path}/painter/Painter.hpp
-    ${include_path}/painter/PerspectiveProjectionCapability.h
-    ${include_path}/painter/AbstractProjectionCapability.h
-    ${include_path}/painter/ContextFormat.h
-    ${include_path}/painter/Camera.h
-    ${include_path}/painter/TypedRenderTargetCapability.h
-    ${include_path}/painter/AbstractViewportCapability.h
-    ${include_path}/painter/Painter.h
-    ${include_path}/painter/AbstractTargetFramebufferCapability.h
+    ${include_path}/painter/AbstractCameraCapability.h
     ${include_path}/painter/AbstractCapability.h
     ${include_path}/painter/AbstractCapability.hpp
-    ${include_path}/painter/ViewportCapability.h
-    ${include_path}/painter/VirtualTimeCapability.h
-    ${include_path}/painter/CameraCapability.h
-    ${include_path}/painter/AbstractPerspectiveProjectionCapability.h
     ${include_path}/painter/AbstractContext.h
-    ${include_path}/painter/TargetFramebufferCapability.h
-    ${include_path}/painter/AbstractCameraCapability.h
-    ${include_path}/painter/AbstractVirtualTimeCapability.h
-    ${include_path}/painter/AbstractTypedRenderTargetCapability.h
+    ${include_path}/painter/AbstractDevicePixelRatioCapability.h
+    ${include_path}/painter/AbstractInputCapability.h
     ${include_path}/painter/AbstractMetaInformationCapability.h
-    ${include_path}/painter/MetaInformationCapability.h
+    ${include_path}/painter/AbstractOrthographicProjectionCapability.h
     ${include_path}/painter/AbstractOutputCapability.h
     ${include_path}/painter/AbstractOutputCapability.hpp
-    ${include_path}/painter/PipelineOutputCapability.h
-    ${include_path}/painter/AbstractOrthographicProjectionCapability.h
+    ${include_path}/painter/AbstractPerspectiveProjectionCapability.h
+    ${include_path}/painter/AbstractProjectionCapability.h
+    ${include_path}/painter/AbstractTargetFramebufferCapability.h
+    ${include_path}/painter/AbstractTypedRenderTargetCapability.h
+    ${include_path}/painter/AbstractViewportCapability.h
+    ${include_path}/painter/AbstractVirtualTimeCapability.h
+    ${include_path}/painter/Camera.h
+    ${include_path}/painter/CameraCapability.h
+    ${include_path}/painter/ContextFormat.h
+    ${include_path}/painter/DevicePixelRatioCapability.h
+    ${include_path}/painter/InputCapability.h
+    ${include_path}/painter/MetaInformationCapability.h
     ${include_path}/painter/OrthographicProjectionCapability.h
+    ${include_path}/painter/Painter.h
+    ${include_path}/painter/Painter.hpp
+    ${include_path}/painter/PerspectiveProjectionCapability.h
+    ${include_path}/painter/PipelineOutputCapability.h
+    ${include_path}/painter/TargetFramebufferCapability.h
+    ${include_path}/painter/TypedRenderTargetCapability.h
+    ${include_path}/painter/ViewportCapability.h
+    ${include_path}/painter/VirtualTimeCapability.h
     
     ${include_path}/pipeline/AbstractData.h
     ${include_path}/pipeline/AbstractPipeline.hpp

--- a/source/gloperate/include/gloperate/painter/AbstractDevicePixelRatioCapability.h
+++ b/source/gloperate/include/gloperate/painter/AbstractDevicePixelRatioCapability.h
@@ -1,0 +1,40 @@
+
+#pragma once
+
+
+#include <gloperate/gloperate_api.h>
+#include <gloperate/painter/AbstractCapability.h>
+
+
+namespace gloperate 
+{
+
+/**
+ *  @brief
+ *    Capability that allows for specifying the device pixel ratio
+ */
+class GLOPERATE_API AbstractDevicePixelRatioCapability : public AbstractCapability
+{
+public:
+    virtual ~AbstractDevicePixelRatioCapability();
+
+    /**
+     *  @brief
+     *    Get device pixel ratio
+     *
+     *  @return
+     *    device pixel ratio
+     */
+    virtual float devicePixelRatio() const = 0;
+
+    /**
+     *  @brief
+     *    Set device pixel ratio
+     *
+     *  @param[in] ratio
+     *    device pixel ratio
+     */
+    virtual void setDevicePixelRatio(float ratio) = 0;
+};
+
+} // namespace gloperate

--- a/source/gloperate/include/gloperate/painter/DevicePixelRatioCapability.h
+++ b/source/gloperate/include/gloperate/painter/DevicePixelRatioCapability.h
@@ -1,0 +1,31 @@
+
+#pragma once
+
+
+#include <gloperate/gloperate_api.h>
+#include <gloperate/painter/AbstractDevicePixelRatioCapability.h>
+
+
+namespace gloperate
+{
+
+
+/**
+ *  @brief
+ *    Default implementation for AbstractDevicePixelRatioCapability
+ */
+class GLOPERATE_API DevicePixelRatioCapability : public AbstractDevicePixelRatioCapability
+{
+public:
+    DevicePixelRatioCapability();
+
+    // Virtual functions from AbstractDevicePixelRatioCapability
+    virtual float devicePixelRatio() const override;
+    virtual void setDevicePixelRatio(float ratio) override;
+
+protected:
+    float m_ratio;
+};
+
+
+} // namespace gloperate

--- a/source/gloperate/source/painter/AbstractDevicePixelRatioCapability.cpp
+++ b/source/gloperate/source/painter/AbstractDevicePixelRatioCapability.cpp
@@ -1,0 +1,10 @@
+
+#include <gloperate/painter/AbstractDevicePixelRatioCapability.h>
+
+
+namespace gloperate
+{
+
+AbstractDevicePixelRatioCapability::~AbstractDevicePixelRatioCapability() = default;
+
+} // namespace gloperate

--- a/source/gloperate/source/painter/DevicePixelRatioCapability.cpp
+++ b/source/gloperate/source/painter/DevicePixelRatioCapability.cpp
@@ -1,0 +1,25 @@
+
+#include <gloperate/painter/DevicePixelRatioCapability.h>
+
+
+namespace gloperate
+{
+
+DevicePixelRatioCapability::DevicePixelRatioCapability()
+:   m_ratio{1.0}
+{
+}
+
+float DevicePixelRatioCapability::devicePixelRatio() const
+{
+    return m_ratio;
+}
+
+void DevicePixelRatioCapability::setDevicePixelRatio(float ratio)
+{
+    m_ratio = ratio;
+
+    setChanged(true);
+}
+
+} // namespace gloperate


### PR DESCRIPTION
This capability that allows for specifying the device pixel ratio on painters that support it. It is especially meant to be used to render the scene in standard resolution on Macs with high resolution displays.