### PR TITLE
Add missing virtual default destructor for PipelinePainter

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/PipelinePainter.h
+++ b/source/gloperate/include/gloperate/pipeline/PipelinePainter.h
@@ -32,6 +32,7 @@ public:
         gloperate::ResourceManager & resourceManager, 
         AbstractPipeline & pipeline, 
         const std::string & name = "painter");
+    virtual ~PipelinePainter() = default;
 
     virtual void onInitialize() override;
     virtual void onPaint() override;


### PR DESCRIPTION
Virtual destructor is needed for dynamic cast to child class of PipelinePainter.