### PR TITLE
Fix run-time exception in ScreenAligned example

### DIFF
--- a/source/examples/globjects-painters/screenaligned/ScreenAligned.cpp
+++ b/source/examples/globjects-painters/screenaligned/ScreenAligned.cpp
@@ -66,7 +66,7 @@ void ScreenAligned::createAndSetupTexture()
     std::poisson_distribution<> r(0.2);
 
     for (int i = 0; i < w * h * 4; ++i) {
-        data[i] = static_cast<unsigned char>(255 - static_cast<unsigned char>(r(generator) * 255));
+        data[i] = static_cast<unsigned char>((255 - static_cast<unsigned char>((r(generator) * 255) & 0xFF)) & 0xFF);
     }
 
     m_texture = globjects::Texture::createDefault(gl::GL_TEXTURE_2D);


### PR DESCRIPTION
Fix run-time exception (A cast to a smaller data type has caused a loss of data.) in ScreenAligned example by adding 2 bit masks before the conversions