### PR TITLE
On startup the canvas is not shown with the right size/position eg. on windows

### DIFF
--- a/source/gloperate-qt/include/gloperate-qt/viewer/Viewer.h
+++ b/source/gloperate-qt/include/gloperate-qt/viewer/Viewer.h
@@ -150,6 +150,21 @@ public:
     //@}
 
 
+public slots:
+    //@{
+    /**
+    *  @brief
+    *    Extends QWindow::show() to resize Canvas on startup
+    *
+    *  @remarks
+    *    Not all plattforms send resize events on QWindow startup.
+    *    YOu have to resize the window in order to show the canvas
+    *    correct.
+    */
+    virtual void show();
+    //@}
+
+
 protected:
     void setupMessageWidgets();
     void setupCommandPrompt();

--- a/source/gloperate-qt/source/viewer/Viewer.cpp
+++ b/source/gloperate-qt/source/viewer/Viewer.cpp
@@ -345,6 +345,24 @@ void Viewer::setupCanvas()
     m_mapping->addProvider(wheelProvider);
 }
 
+void Viewer::show()
+{
+    // Call superclass function
+    QMainWindow::show();
+
+    // Resize window in order to show canvas correct
+    if (width() > 0)
+    {
+        QMainWindow::resize(QSize(width() - 1, height() - 1));
+        QMainWindow::resize(QSize(width() + 1, height() + 1));
+    }
+    else
+    {
+        QMainWindow::resize(QSize(width() + 1, height() + 1));
+        QMainWindow::resize(QSize(width() - 1, height() - 1));
+    }
+}
+
 void Viewer::setupScripting()
 {
     // Widgets have to be created beforehand


### PR DESCRIPTION
Send a resize event to the main window on startup so you have not to rely on QT doing it on all platforms.