### PR TITLE
Slot validity

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/AbstractDataSlot.h
+++ b/source/gloperate/include/gloperate/pipeline/AbstractDataSlot.h
@@ -39,12 +39,18 @@ public:
 
     /**
     *  @brief
-    *    Invalidate output
+    *    Set validity of data
     *
-    *    This marks the output value as invalid.
-    *    The state will remain until a new value is set.
+    *  @remarks
+    *    This marks the output value as valid or invalid.
+    *    The state will automatically change to valid when a new value is set.
+    *
+    *  @see
+    *    isValid
+    *  @see
+    *    setValue
     */
-    virtual void invalidate() = 0;
+    virtual void setValid(bool isValid) = 0;
 
 
 protected:

--- a/source/gloperate/include/gloperate/pipeline/Output.h
+++ b/source/gloperate/include/gloperate/pipeline/Output.h
@@ -40,25 +40,10 @@ public:
     virtual ~Output();
 
     // Virtual AbstractDataSlot interface
-    virtual void invalidate() override;
+    virtual void setValid(bool isValid) override;
 
     // Virtual AbstractSlot interface
     virtual bool isValid() const override;
-
-    /**
-    *  @brief
-    *    Manually set validity of data
-    *
-    *  @remarks
-    *    This should only be called, if 'setValue()' is not used,
-    *    but the slot contains valid data.
-    *
-    *  @see
-    *    isValid
-    *  @see
-    *    setValue
-    */
-    void setValid(bool isValid);
 
 protected:
     // Virtual AbstractSlot interface

--- a/source/gloperate/include/gloperate/pipeline/Output.h
+++ b/source/gloperate/include/gloperate/pipeline/Output.h
@@ -45,6 +45,20 @@ public:
     // Virtual AbstractSlot interface
     virtual bool isValid() const override;
 
+    /**
+    *  @brief
+    *    Manually set validity of data
+    *
+    *  @remarks
+    *    This should only be called, if 'setValue()' is not used,
+    *    but the slot contains valid data.
+    *
+    *  @see
+    *    isValid
+    *  @see
+    *    setValue
+    */
+    void setValid(bool isValid);
 
 protected:
     // Virtual AbstractSlot interface

--- a/source/gloperate/include/gloperate/pipeline/Output.inl
+++ b/source/gloperate/include/gloperate/pipeline/Output.inl
@@ -24,10 +24,10 @@ Output<T>::~Output()
 }
 
 template <typename T>
-void Output<T>::invalidate()
+void Output<T>::setValid(bool isValid)
 {
-    // Set state to invalid
-    m_valid = false;
+    // Set state to new state
+    m_valid = isValid;
 
     // Emit signal
     this->valueChanged(this->m_value);
@@ -57,12 +57,6 @@ void Output<T>::onValueChanged(const T & value)
 
     // Emit signal
     this->valueChanged(value);
-}
-
-template <typename T>
-void Output<T>::setValid(bool isValid)
-{
-    m_valid = isValid;
 }
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/Output.inl
+++ b/source/gloperate/include/gloperate/pipeline/Output.inl
@@ -59,5 +59,10 @@ void Output<T>::onValueChanged(const T & value)
     this->valueChanged(value);
 }
 
+template <typename T>
+void Output<T>::setValid(bool isValid)
+{
+    m_valid = isValid;
+}
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/Parameter.h
+++ b/source/gloperate/include/gloperate/pipeline/Parameter.h
@@ -40,7 +40,7 @@ public:
     virtual ~Parameter();
 
     // Virtual AbstractDataSlot interface
-    virtual void invalidate() override;
+    virtual void setValid(bool isValid) override;
 
     // Virtual AbstractSlot interface
     virtual bool isValid() const override;

--- a/source/gloperate/include/gloperate/pipeline/Parameter.inl
+++ b/source/gloperate/include/gloperate/pipeline/Parameter.inl
@@ -23,7 +23,7 @@ Parameter<T>::~Parameter()
 }
 
 template <typename T>
-void Parameter<T>::invalidate()
+void Parameter<T>::setValid(bool isValid)
 {
     // Parameters are always valid
 }


### PR DESCRIPTION
`setValid(bool isValid)` method so a slot can be set to valid, without setting the value directly