### PR TITLE
Context info & format improvements

### DIFF
--- a/source/examples/gloperate-glfw-example/main.cpp
+++ b/source/examples/gloperate-glfw-example/main.cpp
@@ -49,6 +49,7 @@ int main(int argc, char * argv[])
 //  window.context()->setSwapInterval(Context::SwapInterval::VerticalSyncronization);
     cppassist::info() << std::endl
         << "OpenGL Version:  " << GLContextUtils::version() << std::endl
+        << "OpenGL Profile:  " << GLContextUtils::profile() << std::endl
         << "OpenGL Vendor:   " << GLContextUtils::vendor() << std::endl
         << "OpenGL Renderer: " << GLContextUtils::renderer() << std::endl;
     window.context()->release();

--- a/source/examples/gloperate-qt-example/main.cpp
+++ b/source/examples/gloperate-qt-example/main.cpp
@@ -86,6 +86,7 @@ int main(int argc, char * argv[])
 //  window->context()->setSwapInterval(Context::SwapInterval::VerticalSyncronization);
     cppassist::info() << std::endl
         << "OpenGL Version:  " << GLContextUtils::version() << std::endl
+        << "OpenGL Profile:  " << GLContextUtils::profile() << std::endl
         << "OpenGL Vendor:   " << GLContextUtils::vendor() << std::endl
         << "OpenGL Renderer: " << GLContextUtils::renderer() << std::endl;
     window->context()->release();

--- a/source/gloperate/include/gloperate/base/GLContextFormat.h
+++ b/source/gloperate/include/gloperate/base/GLContextFormat.h
@@ -41,7 +41,6 @@ public:
         Default         ///< The default swap behaviour (of the platform).
       , SingleBuffering ///< Might result in flickering when is done directly to screen without an intermediate offscreen buffer.
       , DoubleBuffering ///< Rendering is done to the back buffer, which is then swapped with the front buffer.
-      , TripleBuffering ///< Sometimes used in order to decrease the risk of skipping a frame when the rendering rate is just barely keeping up with the screen refresh rate.
     };
 
 

--- a/source/gloperate/include/gloperate/base/GLContextUtils.h
+++ b/source/gloperate/include/gloperate/base/GLContextUtils.h
@@ -71,6 +71,15 @@ public:
 
     /**
     *  @brief
+    *    Read OpenGL profile from current context
+    *
+    *  @notes
+    *    - Requires active context
+    */
+    static GLContextFormat::Profile retrieveProfile();
+
+    /**
+    *  @brief
     *    Get OpenGL version
     *
     *  @return
@@ -80,6 +89,18 @@ public:
     *    - Requires active context
     */
     static std::string version();
+
+    /**
+    *  @brief
+    *    Get OpenGL profile
+    *
+    *  @return
+    *    OpenGL profile string
+    *
+    *  @notes
+    *    - Requires active context
+    */
+    static std::string profile();
 
     /**
     *  @brief

--- a/source/gloperate/source/base/GLContextFormat.cpp
+++ b/source/gloperate/source/base/GLContextFormat.cpp
@@ -30,8 +30,7 @@ const std::string & GLContextFormat::swapBehaviorString(const SwapBehavior swapB
     {
         { SwapBehavior::Default,         "Default" }
       , { SwapBehavior::DoubleBuffering, "DoubleBuffering" }
-      , { SwapBehavior::SingleBuffering, "SingleBuffering" } 
-      , { SwapBehavior::TripleBuffering, "TripleBuffering" }
+      , { SwapBehavior::SingleBuffering, "SingleBuffering" }
     };
 
     return swapbIdentifier.at(swapBehavior);

--- a/source/gloperate/source/base/GLContextUtils.cpp
+++ b/source/gloperate/source/base/GLContextUtils.cpp
@@ -16,6 +16,15 @@ namespace gloperate
 {
 
 
+namespace
+{
+// these are not part of the OpenGL specification, but defined identically
+// in all platform-specific context creation APIs
+const auto GL_CONTEXT_CORE_PROFILE_BIT          = 0x1;
+const auto GL_CONTEXT_COMPATIBILITY_PROFILE_BIT = 0x2;
+}
+
+
 bool GLContextUtils::isValid()
 {
     return (tryFetchHandle() > 0);
@@ -48,6 +57,8 @@ gloperate::GLContextFormat GLContextUtils::retrieveFormat()
     GLboolean b;
 
     format.setVersion(retrieveVersion());
+
+    format.setProfile(retrieveProfile());
 
     i = -1; glGetIntegerv(GLenum::GL_RED_BITS, &i);
     format.setRedBufferSize(i);
@@ -106,11 +117,41 @@ glbinding::Version GLContextUtils::retrieveVersion()
     return glbinding::Version(major, minor);
 }
 
+GLContextFormat::Profile GLContextUtils::retrieveProfile()
+{
+    assert(0 != glbinding::getCurrentContext());
+
+    GLint profileMask = -1;
+    glGetIntegerv(GLenum::GL_CONTEXT_PROFILE_MASK, &profileMask);
+
+    if (profileMask <= 0) // probably a context < 3.2 with no support for profiles
+    {
+        return GLContextFormat::Profile::None;
+    }
+
+    if ((profileMask & GL_CONTEXT_CORE_PROFILE_BIT) != 0)
+    {
+        return GLContextFormat::Profile::Core;
+    }
+    
+    if ((profileMask & GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0)
+    {
+        return GLContextFormat::Profile::Compatibility;
+    }
+
+    return GLContextFormat::Profile::None;
+}
+
 std::string GLContextUtils::version()
 {
     assert(0 != glbinding::getCurrentContext());
 
     return glbinding::ContextInfo::version().toString();
+}
+
+std::string GLContextUtils::profile()
+{
+    return GLContextFormat::profileString(retrieveProfile());
 }
 
 std::string GLContextUtils::vendor()

--- a/source/gloperate/source/base/GLContextUtils.cpp
+++ b/source/gloperate/source/base/GLContextUtils.cpp
@@ -16,15 +16,6 @@ namespace gloperate
 {
 
 
-namespace
-{
-// these are not part of the OpenGL specification, but defined identically
-// in all platform-specific context creation APIs
-const auto GL_CONTEXT_CORE_PROFILE_BIT          = 0x1;
-const auto GL_CONTEXT_COMPATIBILITY_PROFILE_BIT = 0x2;
-}
-
-
 bool GLContextUtils::isValid()
 {
     return (tryFetchHandle() > 0);
@@ -129,12 +120,12 @@ GLContextFormat::Profile GLContextUtils::retrieveProfile()
         return GLContextFormat::Profile::None;
     }
 
-    if ((profileMask & GL_CONTEXT_CORE_PROFILE_BIT) != 0)
+    if ((profileMask & static_cast<GLint>(GL_CONTEXT_CORE_PROFILE_BIT)) != 0)
     {
         return GLContextFormat::Profile::Core;
     }
     
-    if ((profileMask & GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0)
+    if ((profileMask & static_cast<GLint>(GL_CONTEXT_COMPATIBILITY_PROFILE_BIT)) != 0)
     {
         return GLContextFormat::Profile::Compatibility;
     }


### PR DESCRIPTION
Two minor improvements for context info and format (in preparation for #166):
- Remove `SwapBehavior::TripleBuffer` as this is not actually configurable on any OpenGL platform (I don't know why Qt has it, they treat it identical to DoubleBuffer), see https://www.opengl.org/wiki/Common_Mistakes#Triple_Buffering
- Add functions to retrieve the OpenGL profile of the current context

Question: `gloperate::GLContextInfo::retrieveVersion()` and `glbinding::ContextInfo::version()` seem to do the same thing, is the former necessary?
