### PR TITLE
Cyclic dependency detection

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/Input.inl
+++ b/source/gloperate/include/gloperate/pipeline/Input.inl
@@ -29,6 +29,8 @@ Input<T>::~Input()
 template <typename T>
 void Input<T>::onValueChanged(const T & value)
 {
+    std::lock_guard<std::recursive_mutex> lock(this->m_cycleMutex);
+
     // Get current thread ID
     std::thread::id this_id = std::this_thread::get_id();
 

--- a/source/gloperate/include/gloperate/pipeline/Input.inl
+++ b/source/gloperate/include/gloperate/pipeline/Input.inl
@@ -2,6 +2,9 @@
 #pragma once
 
 
+#include <cppassist/logging/logging.h>
+
+
 namespace gloperate
 {
 
@@ -26,6 +29,29 @@ Input<T>::~Input()
 template <typename T>
 void Input<T>::onValueChanged(const T & value)
 {
+    // Get current thread ID
+    std::thread::id this_id = std::this_thread::get_id();
+
+    // Initialize guard for the current thread
+    if (this->m_cycleGuard.find(this_id) == this->m_cycleGuard.end())
+    {
+        this->m_cycleGuard[this_id] = false;
+    }
+
+    // Check if this slot has already been invoked in the current recursion
+    if (this->m_cycleGuard[this_id])
+    {
+        // Reset guard
+        this->m_cycleGuard[this_id] = false;
+
+        // Stop recursion here to avoid endless recursion
+        cppassist::warning() << "detected cyclic dependency for " << this->qualifiedName();
+        return;
+    }
+
+    // Raise guard
+    this->m_cycleGuard[this_id] = true;
+
     // Emit signal
     this->valueChanged(value);
 
@@ -34,6 +60,9 @@ void Input<T>::onValueChanged(const T & value)
     {
         stage->inputValueChanged(this);
     }
+
+    // Reset guard
+    this->m_cycleGuard[this_id] = false;
 }
 
 

--- a/source/gloperate/include/gloperate/pipeline/Output.inl
+++ b/source/gloperate/include/gloperate/pipeline/Output.inl
@@ -48,8 +48,33 @@ void Output<T>::onRequiredChanged()
 template <typename T>
 void Output<T>::onValueChanged(const T & value)
 {
+    // Get current thread ID
+    std::thread::id this_id = std::this_thread::get_id();
+
+    // Initialize guard for the current thread
+    if (this->m_cycleGuard.find(this_id) == this->m_cycleGuard.end())
+    {
+        this->m_cycleGuard[this_id] = false;
+    }
+
+    // Check if this slot has already been invoked in the current recursion
+    if (this->m_cycleGuard[this_id])
+    {
+        // Reset guard
+        this->m_cycleGuard[this_id] = false;
+
+        // Stop recursion here to avoid endless recursion
+        return;
+    }
+
+    // Raise guard
+    this->m_cycleGuard[this_id] = true;
+
     // Emit signal
     this->valueChanged(value);
+
+    // Reset guard
+    this->m_cycleGuard[this_id] = false;
 }
 
 

--- a/source/gloperate/include/gloperate/pipeline/Output.inl
+++ b/source/gloperate/include/gloperate/pipeline/Output.inl
@@ -48,6 +48,8 @@ void Output<T>::onRequiredChanged()
 template <typename T>
 void Output<T>::onValueChanged(const T & value)
 {
+    std::lock_guard<std::recursive_mutex> lock(this->m_cycleMutex);
+
     // Get current thread ID
     std::thread::id this_id = std::this_thread::get_id();
 

--- a/source/gloperate/include/gloperate/pipeline/Slot.h
+++ b/source/gloperate/include/gloperate/pipeline/Slot.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <thread>
+#include <mutex>
 
 #include <cppexpose/typed/DirectValue.h>
 #include <cppexpose/signal/Signal.h>
@@ -155,6 +156,7 @@ protected:
     cppexpose::ScopedConnection m_connection; ///< Connection to changed-signal of source property
 
     std::map<std::thread::id, bool> m_cycleGuard; ///< Protection against cyclic propagation of change-events (one per thread to be thread-safe)
+    std::recursive_mutex            m_cycleMutex; ///< Mutex for accessing the cycle guard map
 };
 
 

--- a/source/gloperate/include/gloperate/pipeline/Slot.h
+++ b/source/gloperate/include/gloperate/pipeline/Slot.h
@@ -2,6 +2,9 @@
 #pragma once
 
 
+#include <map>
+#include <thread>
+
 #include <cppexpose/typed/DirectValue.h>
 #include <cppexpose/signal/Signal.h>
 #include <cppexpose/signal/ScopedConnection.h>
@@ -147,9 +150,11 @@ protected:
 
 
 protected:
-    bool                        m_valid;        ///< Does the slot have a valid value?
-    Slot<T>                   * m_source;       ///< Connected slot (can be null)
-    cppexpose::ScopedConnection m_connection;   ///< Connection to changed-signal of source property
+    bool                        m_valid;      ///< Does the slot have a valid value?
+    Slot<T>                   * m_source;     ///< Connected slot (can be null)
+    cppexpose::ScopedConnection m_connection; ///< Connection to changed-signal of source property
+
+    std::map<std::thread::id, bool> m_cycleGuard; ///< Protection against cyclic propagation of change-events (one per thread to be thread-safe)
 };
 
 

--- a/source/gloperate/include/gloperate/pipeline/Slot.inl
+++ b/source/gloperate/include/gloperate/pipeline/Slot.inl
@@ -166,15 +166,11 @@ void Slot<T>::setValid(bool isValid)
         return;
     }
 
-    // Only update state if state has changed
-    if (m_valid != isValid)
-    {
-        // Set state of own data
-        m_valid = isValid;
+    // Set state of own data
+    m_valid = isValid;
 
-        // Emit signal
-        this->onValueChanged(this->m_value);
-    }
+    // Emit signal
+    this->onValueChanged(this->m_value);
 }
 
 template <typename T>


### PR DESCRIPTION
- Always propagate invalidation of values to restore continuous rendering
- Propose thread-safe detection of cyclic dependencies to avoid endless recursion