### PR TITLE
Add "config" command line parameter to gloperate-qt viewer

### DIFF
--- a/source/gloperate-qt/include/gloperate-qt/viewer/Application.h
+++ b/source/gloperate-qt/include/gloperate-qt/viewer/Application.h
@@ -1,11 +1,16 @@
 
 #pragma once
 
+#include <memory>
+
 #include <gloperate/ext-includes-begin.h>
 #include <QApplication>
 #include <gloperate/ext-includes-end.h>
 
 #include <gloperate-qt/gloperate-qt_api.h>
+
+
+class QSettings;
 
 
 namespace gloperate_qt
@@ -15,8 +20,20 @@ namespace gloperate_qt
 class GLOPERATE_QT_API Application : public QApplication
 {
 public:
+    static std::unique_ptr<QSettings> settings();
+
+
+public:
     Application(int & argc, char ** argv);
     virtual ~Application();
+
+
+private:
+    static Application * self;
+
+
+private:
+    QString m_settingsFilePath;
 };
 
 

--- a/source/gloperate-qt/source/viewer/Application.cpp
+++ b/source/gloperate-qt/source/viewer/Application.cpp
@@ -4,6 +4,8 @@
 #include <gloperate/ext-includes-begin.h>
 #include <QApplication>
 #include <QStringList>
+#include <QCommandLineParser>
+#include <QSettings>
 #include <gloperate/ext-includes-end.h>
 
 #include <widgetzeug/MessageHandler.h>
@@ -13,14 +15,48 @@ namespace gloperate_qt
 {
 
 
+namespace
+{
+const QString ARGNAME_CONFIG{ "config" };
+}
+
+
+Application * Application::self = nullptr;
+
+
 Application::Application(int & argc, char ** argv)
 : QApplication(argc, argv)
 {
+    self = this;
+
 	qInstallMessageHandler(widgetzeug::globalMessageHandler);
+
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+
+    QCommandLineParser parser;
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addOption({ ARGNAME_CONFIG, "Path to the configuration file", "config-path" });
+
+    parser.process(*this);
+
+    // defaults to "" if not set
+    m_settingsFilePath = parser.value(ARGNAME_CONFIG);
 }
+
 
 Application::~Application()
 {
+}
+
+
+std::unique_ptr<QSettings> Application::settings()
+{
+    if (self->m_settingsFilePath.isEmpty())
+    {
+        return std::unique_ptr<QSettings>{new QSettings};
+    }
+    return std::unique_ptr<QSettings>{new QSettings{self->m_settingsFilePath, QSettings::IniFormat}};
 }
 
 

--- a/source/gloperate-qt/source/viewer/Viewer.cpp
+++ b/source/gloperate-qt/source/viewer/Viewer.cpp
@@ -42,6 +42,7 @@
 #include <gloperate-qt/viewer/QtMouseEventProvider.h>
 #include <gloperate-qt/viewer/QtWheelEventProvider.h>
 #include <gloperate-qt/viewer/DefaultMapping.h>
+#include <gloperate-qt/viewer/Application.h>
 #include <gloperate-qt/widgets/ImageExporterWidget.h>
 #include <gloperate-qt/widgets/PluginConfigWidget.h>
 #include <gloperate-qt/scripting/ScriptEnvironment.h>
@@ -130,19 +131,18 @@ Viewer::Viewer(QWidget * parent, Qt::WindowFlags flags)
     setupCanvas();
 
     // Load settings
-    QSettings::setDefaultFormat(QSettings::IniFormat);
-    QSettings settings;
+    const auto settings = Application::settings();
 
     // Restore GUI state from settings
-    restoreGeometry(settings.value(SETTINGS_GEOMETRY).toByteArray());
-    restoreState(settings.value(SETTINGS_STATE).toByteArray());
+    restoreGeometry(settings->value(SETTINGS_GEOMETRY).toByteArray());
+    restoreState(settings->value(SETTINGS_STATE).toByteArray());
 
     // Initialize plugin manager
     m_pluginManager.reset(new PluginManager());
     m_pluginManager->pluginsChanged.connect(this, &Viewer::updatePainterMenu);
 
     // Restore plugin search paths from settings
-    auto paths = fromQStringList(settings.value(SETTINGS_PLUGINS).toStringList());
+    auto paths = fromQStringList(settings->value(SETTINGS_PLUGINS).toStringList());
     if (paths.size() > 0) {
         m_pluginManager->setSearchPaths(paths);
     }
@@ -165,10 +165,10 @@ Viewer::~Viewer()
     m_canvas->doneCurrent();
 
     // Save settings
-    QSettings settings;
-    settings.setValue(SETTINGS_GEOMETRY, saveGeometry());
-    settings.setValue(SETTINGS_STATE, saveState());
-    settings.setValue(SETTINGS_PLUGINS, toQStringList(m_pluginManager->searchPaths()));
+    const auto settings = Application::settings();
+    settings->setValue(SETTINGS_GEOMETRY, saveGeometry());
+    settings->setValue(SETTINGS_STATE, saveState());
+    settings->setValue(SETTINGS_PLUGINS, toQStringList(m_pluginManager->searchPaths()));
 
     // Disconnect message handlers
     MessageHandler::dettach(*m_messagesLog);


### PR DESCRIPTION
... to specify the name of a file used to store settings via `QSettings`. If the parameter is omitted, the default file is used.

`QSettings` must be created through `Application::settings` to honor the option.