### PR TITLE
Fix call to onContextInit without current context

### DIFF
--- a/source/gloperate-qt/source/base/RenderWindow.cpp
+++ b/source/gloperate-qt/source/base/RenderWindow.cpp
@@ -4,6 +4,7 @@
 #include <glm/glm.hpp>
 
 #include <QCoreApplication>
+#include <QOpenGLContext>
 
 #include <gloperate/base/Environment.h>
 #include <gloperate/base/Canvas.h>
@@ -45,7 +46,9 @@ gloperate::Stage * RenderWindow::renderStage() const
 
 void RenderWindow::setRenderStage(gloperate::Stage * stage)
 {
+    m_context->qtContext()->makeCurrent(this);
     m_canvas->setRenderStage(stage);
+    m_context->qtContext()->doneCurrent();
 }
 
 void RenderWindow::onContextInit()


### PR DESCRIPTION
`Canvas::setRenderStage` calls `onContextDeinit` and `onContextInit` on the old/new render stage, thus it requires a current context, which is currently not the case.

This affects the GLFW implementation as well and perhaps QtQuick?
Alternatively, the calls could be made directly in `Canvas::setRenderStage` via the `AbstractContext` interface; however, currently, `Canvas` seems to always assume a current context when any method is called.
Which option would you prefer?