### PR TITLE
Fix wrong event type for mouse move events

### DIFF
--- a/source/gloperate/source/input/MouseDevice.cpp
+++ b/source/gloperate/source/input/MouseDevice.cpp
@@ -21,7 +21,7 @@ MouseDevice::~MouseDevice()
 void MouseDevice::move(const glm::ivec2 & pos)
 {
     auto inputEvent = new MouseEvent{
-        InputEvent::Type::MouseButtonPress,
+        InputEvent::Type::MouseMove,
         this,
         pos
     };


### PR DESCRIPTION
`MouseDevice::move` should generate a `InputEvent::Type::MouseMove` event, not a `InputEvent::Type::MouseButtonPress` event.