### PR TITLE
Base class for render target introduced

### DIFF
--- a/source/gloperate/CMakeLists.txt
+++ b/source/gloperate/CMakeLists.txt
@@ -94,6 +94,8 @@ set(headers
     ${include_path}/rendering/Drawable.h
     ${include_path}/rendering/Drawable.inl
     ${include_path}/rendering/RenderPass.h
+    ${include_path}/rendering/RenderTarget.h
+    ${include_path}/rendering/RenderTargetType.h
 
     ${include_path}/stages/interfaces/RenderInterface.h
     ${include_path}/stages/base/BasicFramebufferStage.h
@@ -166,6 +168,7 @@ set(sources
     ${source_path}/rendering/Camera.cpp
     ${source_path}/rendering/Drawable.cpp
     ${source_path}/rendering/RenderPass.cpp
+    ${source_path}/rendering/RenderTarget.cpp
 
     ${source_path}/stages/interfaces/RenderInterface.cpp
     ${source_path}/stages/base/BasicFramebufferStage.cpp

--- a/source/gloperate/include/gloperate/rendering/RenderTarget.h
+++ b/source/gloperate/include/gloperate/rendering/RenderTarget.h
@@ -113,7 +113,7 @@ protected:
     RenderTargetType                                         m_type;         ///< the current type
 
     union {
-        gl::GLenum                                           m_attachment;   ///< the attachment target
+        gl::GLenum                                           m_attachment;   ///< the default framebuffer attachment target
         globjects::ref_ptr<globjects::Texture>               m_texture;      ///< the texture target
         globjects::ref_ptr<globjects::Renderbuffer>          m_renderbuffer; ///< the renderbuffer target
         globjects::ref_ptr<globjects::FramebufferAttachment> m_userDefined;  ///< the user defined framebuffer attachment

--- a/source/gloperate/include/gloperate/rendering/RenderTarget.h
+++ b/source/gloperate/include/gloperate/rendering/RenderTarget.h
@@ -110,12 +110,14 @@ public:
 
 
 protected:
-    RenderTargetType                                     m_type;         ///< the current type
+    RenderTargetType                                         m_type;         ///< the current type
 
-    gl::GLenum                                           m_attachment;   ///< the attachment target
-    globjects::ref_ptr<globjects::Texture>               m_texture;      ///< the texture target
-    globjects::ref_ptr<globjects::Renderbuffer>          m_renderbuffer; ///< the renderbuffer target
-    globjects::ref_ptr<globjects::FramebufferAttachment> m_userDefined;  ///< the user defined framebuffer attachment
+    union {
+        gl::GLenum                                           m_attachment;   ///< the attachment target
+        globjects::ref_ptr<globjects::Texture>               m_texture;      ///< the texture target
+        globjects::ref_ptr<globjects::Renderbuffer>          m_renderbuffer; ///< the renderbuffer target
+        globjects::ref_ptr<globjects::FramebufferAttachment> m_userDefined;  ///< the user defined framebuffer attachment
+    };
 
 };
 

--- a/source/gloperate/include/gloperate/rendering/RenderTarget.h
+++ b/source/gloperate/include/gloperate/rendering/RenderTarget.h
@@ -1,0 +1,123 @@
+
+#pragma once
+
+
+#include <glbinding/gl/enum.h>
+
+#include <globjects/base/Referenced.h>
+#include <globjects/base/ref_ptr.h>
+
+#include <gloperate/rendering/RenderTargetType.h>
+
+#include <gloperate/gloperate_api.h>
+
+
+namespace globjects
+{
+
+
+class Framebuffer;
+class FramebufferAttachment;
+class Renderbuffer;
+class Texture;
+
+
+} // namespace globjects
+
+
+namespace gloperate
+{
+
+
+/**
+*  @brief
+*    Render target that represents one target we can render into
+*
+*    A render target can internally be: a texture, a renderbuffer,
+*    a symbolic attachment of the default renderbuffer, or a user-defined
+*    renderbuffer with attachment specification.
+*/
+class GLOPERATE_API RenderTarget : public globjects::Referenced
+{
+public:
+    /**
+    *  @brief
+    *    Constructor
+    */
+    RenderTarget();
+
+    /**
+    *  @brief
+    *    Destructor
+    */
+    virtual ~RenderTarget();
+
+    /**
+    *  @brief
+    *    Set a (new) desired target
+    *
+    *  @param[in] texture
+    *    A texture
+    */
+    void setTarget(globjects::Texture * texture);
+
+    /**
+    *  @brief
+    *    Set a (new) desired target
+    *
+    *  @param[in] renderbuffer
+    *    A renderbuffer
+    */
+    void setTarget(globjects::Renderbuffer * renderbuffer);
+
+    /**
+    *  @brief
+    *    Set a (new) desired target
+    *
+    *  @param[in] attachment
+    *    A symbolic attachment of the default renderbuffer
+    */
+    void setTarget(gl::GLenum attachment);
+
+    /**
+    *  @brief
+    *    Set a (new) desired target
+    *
+    *  @param[in] fboAttachment
+    *    A user-defined fbo attachment
+    */
+    void setTarget(globjects::FramebufferAttachment *fboAttachment);
+
+    /**
+    *  @brief
+    *    Binds this render target to a framebuffer
+    *
+    *  @param[in] renderbuffer
+    *    Target framebuffer
+    *
+    *  @param[in] bindingPoint
+    *    Target binding point, e.g. gl::GL_DEPTH_ATTACHMENT
+    *    Will be ignored if not applicable
+    */
+    void bind(gl::GLenum bindingPoint, globjects::Framebuffer * fbo);
+
+    /**
+    *  @brief
+    *    Unbinds this render target
+    */
+    // void unbind();
+
+
+
+protected:
+    RenderTargetType                                     m_type;         ///< the current type
+
+    gl::GLenum                                           m_attachment;   ///< the attachment target
+    globjects::ref_ptr<globjects::Texture>               m_texture;      ///< the texture target
+    globjects::ref_ptr<globjects::Renderbuffer>          m_renderbuffer; ///< the renderbuffer target
+    globjects::ref_ptr<globjects::FramebufferAttachment> m_userDefined;  ///< the user defined framebuffer attachment
+
+};
+
+
+} // namespace gloperate

--- a/source/gloperate/include/gloperate/rendering/RenderTargetType.h
+++ b/source/gloperate/include/gloperate/rendering/RenderTargetType.h
@@ -1,0 +1,79 @@
+
+#pragma once
+
+
+#include <functional>
+#include <cppexpose/typed/TypedEnum.h>
+
+
+namespace gloperate
+{
+
+
+/**
+*  @brief
+*    RenderTargetType enum class for identifying the valid render target
+*/
+enum class RenderTargetType : unsigned int
+{
+    Invalid,                 ///< does not contain a valid render target (yet)
+    Texture,                 ///< texture
+    Renderbuffer,            ///< renderbuffer
+    DefaultFBOAttachment,    ///< symbolic attachment of the default renderbuffer
+    UserDefinedFBOAttachment ///< user-defined renderbuffer with attachment
+};
+
+
+} // namespace gloperate_text
+
+
+namespace std
+{
+
+
+/**
+*  @brief
+*    Hash specialization for RenderTargetType enum class.
+*
+*    Enables the use of RenderTargetType as key type of the unordered collection types.
+*/
+template<>
+struct hash<gloperate::RenderTargetType>
+{
+    std::hash<unsigned char>::result_type operator()(
+        const gloperate::RenderTargetType & arg) const
+    {
+        std::hash<unsigned char> hasher;
+        return hasher(static_cast<unsigned char>(arg));
+    }
+};
+
+
+} // namespace std
+
+
+namespace cppexpose
+{
+
+
+/**
+*  @brief
+*    Template specialization of enum strings for RenderTargetType.
+*/
+template<>
+struct EnumDefaultStrings<gloperate::RenderTargetType>
+{
+    std::map<gloperate::RenderTargetType, std::string> operator()()
+    {
+        return{
+            { gloperate::RenderTargetType::Invalid, "Invalid" },
+            { gloperate::RenderTargetType::Texture, "Texture" },
+            { gloperate::RenderTargetType::Renderbuffer, "Renderbuffer" },
+            { gloperate::RenderTargetType::DefaultFBOAttachment, "DefaultFBOAttachment" },
+            { gloperate::RenderTargetType::UserDefinedFBOAttachment, "UserDefinedFBOAttachment" }
+        };
+    }
+};
+
+
+} // namespace cppexpose

--- a/source/gloperate/include/gloperate/stages/base/FramebufferStage.h
+++ b/source/gloperate/include/gloperate/stages/base/FramebufferStage.h
@@ -27,6 +27,10 @@ class Texture;
 /**
 *  @brief
 *    Stage that maintains a framebuffer attached with all input textures
+*
+*    By default it only has one color texture and one depth texture input.
+*    Additional attachments (of type RenderTarget *) can be added as inputs dynamically.
+*    These will be added as color attachments in order of addition.
 */
 class GLOPERATE_API FramebufferStage : public Stage
 {
@@ -46,6 +50,8 @@ public:
     // Inputs
     Input<RenderTarget *> colorTexture;  ///< Color attachment (#0)
     Input<RenderTarget *> depthTexture;  ///< Depth attachment
+
+    // Additional attachments (of type RenderTarget *) can be added as inputs dynamically
 
     // Outputs
     Output<globjects::Framebuffer *> fbo;      ///< Framebuffer
@@ -78,7 +84,7 @@ protected:
 
     // Helper functions
     void rebuildFBO();
-    bool isNameOfDepthRenderTarget(std::string name);
+    bool isNameOfDepthRenderTarget(const std::string & name);
 
 
 protected:

--- a/source/gloperate/include/gloperate/stages/base/FramebufferStage.h
+++ b/source/gloperate/include/gloperate/stages/base/FramebufferStage.h
@@ -8,7 +8,6 @@
 
 #include <globjects/base/ref_ptr.h>
 #include <globjects/Framebuffer.h>
-#include <globjects/Texture.h>
 
 #include <gloperate/gloperate-version.h>
 #include <gloperate/base/ExtendedProperties.h>
@@ -19,6 +18,10 @@
 
 namespace gloperate
 {
+
+
+class RenderTarget;
+class Texture;
 
 
 /**
@@ -41,8 +44,8 @@ public:
 
 public:
     // Inputs
-    Input<globjects::Texture *> colorTexture;  ///< Color attachment (#0)
-    Input<globjects::Texture *> depthTexture;  ///< Depth attachment
+    Input<RenderTarget *> colorTexture;  ///< Color attachment (#0)
+    Input<RenderTarget *> depthTexture;  ///< Depth attachment
 
     // Outputs
     Output<globjects::Framebuffer *> fbo;      ///< Framebuffer
@@ -75,6 +78,7 @@ protected:
 
     // Helper functions
     void rebuildFBO();
+    bool isNameOfDepthRenderTarget(std::string name);
 
 
 protected:

--- a/source/gloperate/include/gloperate/stages/base/TextureStage.h
+++ b/source/gloperate/include/gloperate/stages/base/TextureStage.h
@@ -21,6 +21,11 @@ namespace globjects
     class Texture;
 }
 
+namespace gloperate
+{
+    class RenderTarget;
+}
+
 
 namespace gloperate
 {
@@ -49,10 +54,11 @@ public:
     Input<gl::GLenum> internalFormat;     ///< OpenGL internal image format
     Input<gl::GLenum> format;             ///< OpenGL image format
     Input<gl::GLenum> type;               ///< OpenGL data type
-    Input<glm::vec2>  size;               ///< Image size
+    Input<glm::vec4>  size;               ///< Viewport size
 
     // Outputs
-    Output<globjects::Texture *> texture; ///< Texture
+    Output<globjects::Texture *> texture;           ///< Texture
+    Output<gloperate::RenderTarget *> renderTarget; ///< RenderTarget
 
 
 public:
@@ -84,6 +90,7 @@ protected:
 protected:
     // Data
     globjects::ref_ptr<globjects::Texture> m_texture; ///< The created texture
+    globjects::ref_ptr<gloperate::RenderTarget> m_renderTarget; ///< The passed render target
 };
 
 

--- a/source/gloperate/include/gloperate/stages/demos/DemoPipeline.h
+++ b/source/gloperate/include/gloperate/stages/demos/DemoPipeline.h
@@ -16,10 +16,12 @@ namespace gloperate
 
 
 class BasicFramebufferStage;
+class FramebufferStage;
 class TextureLoadStage;
 class MixerStage;
 class TimerStage;
 class SpinningRectStage;
+class TextureStage;
 class ColorizeStage;
 
 
@@ -83,7 +85,10 @@ protected:
     BasicFramebufferStage  * m_framebufferStage1;   ///< Framebuffer for rendering the spinning rect
     SpinningRectStage      * m_spinningRectStage;   ///< Stage that renders the spinning rect
 
-    BasicFramebufferStage  * m_framebufferStage2;   ///< Framebuffer for rendering the colorized output
+    TextureStage           * m_textureStage1;       ///< Texture 1 for 2nd frame buffer
+    TextureStage           * m_textureStage2;       ///< Texture 2 for 2nd frame buffer
+
+    FramebufferStage       * m_framebufferStage2;   ///< Framebuffer for rendering the colorized output
     ColorizeStage          * m_colorizeStage;       ///< Stage that blends the image with a color
 
     MixerStage             * m_mixerStage;          ///< Stage that renders the output to the screen

--- a/source/gloperate/source/rendering/RenderTarget.cpp
+++ b/source/gloperate/source/rendering/RenderTarget.cpp
@@ -1,0 +1,83 @@
+
+#include <gloperate/rendering/RenderTarget.h>
+
+#include <globjects/Framebuffer.h>
+#include <globjects/FramebufferAttachment.h>
+#include <globjects/Renderbuffer.h>
+#include <globjects/Texture.h>
+
+
+namespace gloperate
+{
+
+
+RenderTarget::RenderTarget()
+: m_type(RenderTargetType::Invalid)
+{
+}
+
+RenderTarget::~RenderTarget()
+{
+}
+
+void RenderTarget::setTarget(globjects::Texture *texture)
+{
+    m_type = RenderTargetType::Texture;
+
+    m_texture = texture;
+}
+
+void RenderTarget::setTarget(globjects::Renderbuffer *renderbuffer)
+{
+    m_type = RenderTargetType::Renderbuffer;
+
+    m_renderbuffer = renderbuffer;
+}
+
+void RenderTarget::setTarget(gl::GLenum attachment)
+{
+    m_type = RenderTargetType::DefaultFBOAttachment;
+
+    m_attachment = attachment;
+}
+
+void RenderTarget::setTarget(globjects::FramebufferAttachment *fboAttachment)
+{
+    m_type = RenderTargetType::UserDefinedFBOAttachment;
+
+    m_userDefined = fboAttachment;
+}
+
+void RenderTarget::bind(gl::GLenum bindingPoint, globjects::Framebuffer * fbo)
+{
+    assert(fbo != nullptr);
+    assert(!fbo->isDefault());
+
+    switch (m_type)
+    {
+    case RenderTargetType::Texture:
+        fbo->attachTexture(bindingPoint, m_texture);
+        break;
+    case RenderTargetType::Renderbuffer:
+        // ToDo
+        break;
+    case RenderTargetType::DefaultFBOAttachment:
+        // ToDo
+        break;
+    case RenderTargetType::UserDefinedFBOAttachment:
+        // ToDo
+        break;
+    case RenderTargetType::Invalid:
+    default:
+        // [TODO] show error/warning?
+        break;
+    }
+}
+
+// void RenderTarget::unbind()
+// {
+//     // ToDo
+// }
+
+
+} // namespace gloperate

--- a/source/gloperate/source/rendering/RenderTarget.cpp
+++ b/source/gloperate/source/rendering/RenderTarget.cpp
@@ -59,7 +59,7 @@ void RenderTarget::bind(gl::GLenum bindingPoint, globjects::Framebuffer * fbo)
         fbo->attachTexture(bindingPoint, m_texture);
         break;
     case RenderTargetType::Renderbuffer:
-        // ToDo
+        fbo->attachRenderBuffer(bindingPoint, m_renderbuffer);
         break;
     case RenderTargetType::DefaultFBOAttachment:
         // ToDo

--- a/source/gloperate/source/stages/base/FramebufferStage.cpp
+++ b/source/gloperate/source/stages/base/FramebufferStage.cpp
@@ -3,6 +3,10 @@
 
 #include <glbinding/gl/gl.h>
 
+#include <globjects/Texture.h>
+
+#include <gloperate/rendering/RenderTarget.h>
+
 
 namespace gloperate
 {
@@ -50,15 +54,8 @@ void FramebufferStage::rebuildFBO()
     m_fbo = new globjects::Framebuffer;
 
     // Attach textures to FBO
-    // [TODO] Iterate over dynamic inputs
-    m_fbo->setDrawBuffers({ gl::GL_COLOR_ATTACHMENT0 });
-    m_fbo->attachTexture(gl::GL_COLOR_ATTACHMENT0, *colorTexture);
-    m_fbo->attachTexture(gl::GL_DEPTH_ATTACHMENT,  *depthTexture);
-
-/*
-    // Attach textures to FBO
     std::vector<gl::GLenum> colorAttachments;
-    for (int i=0; i<=1; i++) {
+    for (int i = 0; i <= 1; i++) {
         // First round: Count number of color attachments
         // Second round: Actually attach the textures
         gl::GLenum index = gl::GL_COLOR_ATTACHMENT0;
@@ -67,30 +64,41 @@ void FramebufferStage::rebuildFBO()
         }
 
         for (auto input : this->inputs()) {
-            if (auto slot = dynamic_cast<gloperate::InputSlot<globjects::Texture *> *>(input)) {
-                // Get texture (if set)
-                globjects::Texture * texture = slot->data();
-                if (texture && i == 0) {
-                    if (slot->name() != "texDepth") {
-                        // Add color attachment
-                        colorAttachments.push_back(index);
-                        index = index + 1;
-                    }
-                } else if (texture && i == 1) {
-                    if (slot->name() == "texDepth") {
-                        // Add depth attachment
-                        m_fbo->attachTexture(gl::GL_DEPTH_ATTACHMENT, texture);
-                    } else {
-                        // Add color attachment
-                        m_fbo->attachTexture(index, texture);
-                        index = index + 1;
-                    }
+            auto slot = dynamic_cast<Input<RenderTarget *> *>(input);
+            if (!slot) {
+                continue;
+            }
+            RenderTarget * texture = **slot;
+            if (!texture)
+            {
+                continue;
+            }
+
+            if (i == 0) {
+                if (!isNameOfDepthRenderTarget(slot->name())) {
+                    // Add color attachment
+                    colorAttachments.push_back(index);
+                    index = index + 1;
+                }
+            } else {
+                if (isNameOfDepthRenderTarget(slot->name())) {
+                    // Add depth attachment
+                    texture->bind(gl::GL_DEPTH_ATTACHMENT, m_fbo);
+                } else {
+                    // Add color attachment
+                    texture->bind(index, m_fbo);
+                    index = index + 1;
                 }
             }
         }
     }
-*/
 }
+
+bool FramebufferStage::isNameOfDepthRenderTarget(std::string name)
+{
+    return name.find("Depth") != std::string::npos || name.find("depth") != std::string::npos;
+}
+
 
 
 } // namespace gloperate

--- a/source/gloperate/source/stages/base/FramebufferStage.cpp
+++ b/source/gloperate/source/stages/base/FramebufferStage.cpp
@@ -94,7 +94,7 @@ void FramebufferStage::rebuildFBO()
     }
 }
 
-bool FramebufferStage::isNameOfDepthRenderTarget(std::string name)
+bool FramebufferStage::isNameOfDepthRenderTarget(const std::string & name)
 {
     return name.find("Depth") != std::string::npos || name.find("depth") != std::string::npos;
 }

--- a/source/gloperate/source/stages/base/TextureStage.cpp
+++ b/source/gloperate/source/stages/base/TextureStage.cpp
@@ -8,6 +8,8 @@
 
 #include <globjects/Texture.h>
 
+#include <gloperate/rendering/RenderTarget.h>
+
 
 using namespace gl;
 using namespace globjects;
@@ -27,6 +29,7 @@ TextureStage::TextureStage(gloperate::Environment * environment, const std::stri
 , type("type", this)
 , size("size", this)
 , texture("texture", this)
+, renderTarget("renderTarget", this)
 {
 }
 
@@ -38,12 +41,17 @@ void TextureStage::onContextInit(gloperate::AbstractGLContext *)
 {
     // Create new texture
     m_texture = Texture::createDefault(GL_TEXTURE_2D);
+    // Create wrapping render target
+    m_renderTarget = new RenderTarget();
+    m_renderTarget->setTarget(m_texture);
 }
 
 void TextureStage::onContextDeinit(AbstractGLContext *)
 {
     // Release texture
     m_texture = nullptr;
+    // Release render target
+    m_renderTarget = nullptr;
 }
 
 void TextureStage::onProcess(gloperate::AbstractGLContext *)
@@ -55,12 +63,13 @@ void TextureStage::onProcess(gloperate::AbstractGLContext *)
     }
 
     // Create texture image
-    const auto width  = (*size).x;
-    const auto height = (*size).y;
+    const auto width  = (*size)[2];
+    const auto height = (*size)[3];
     m_texture->image2D(0, *internalFormat, width, height, 0, *format, *type, nullptr);
 
-    // Update output value
+    // Update output values
     texture.setValue(m_texture);
+    renderTarget.setValue(m_renderTarget);
 }
 
 


### PR DESCRIPTION
Other changes combined with this:

- `TextureStage` changed (#201):
    - Uses `glm::vec4` now (i.e. viewport)
    - New `RenderTarget` output, wraps output `Texture`
- `FramebufferStage` adapted:
    - Combines multiple `RenderTarget`s into an FBO
    - Currently two default inputs for depth and color

This is only the very basic implementation, further methods for reading from a `RenderTarget` and a possible example case need to be done. 