### PR TITLE
Remove unnecessary std::endl from log messages

### DIFF
--- a/source/gloperate/source/pipeline/Pipeline.cpp
+++ b/source/gloperate/source/pipeline/Pipeline.cpp
@@ -128,7 +128,7 @@ bool Pipeline::destroyStage(Stage * stage)
 
 void Pipeline::invalidateStageOrder()
 {
-    debug() << "Invalidate stage order; resort on next process" << std::endl;
+    debug() << "Invalidate stage order; resort on next process";
     m_sorted = false;
 }
 
@@ -203,7 +203,7 @@ void Pipeline::sortStages()
 
         if (touched.count(stage) > 0)
         {
-            critical() << "Pipeline is not a directed acyclic graph" << std::endl;
+            critical() << "Pipeline is not a directed acyclic graph";
             couldBeSorted = false;
             sorted.push_back(stage);
             return;


### PR DESCRIPTION
As per cppassist convention, adding newlines at the end of log message is the responsibility of the active log handler, not the using code.