### PR TITLE
Add State applied after rendering to RenderPass

### DIFF
--- a/source/gloperate/include/gloperate/rendering/RenderPass.h
+++ b/source/gloperate/include/gloperate/rendering/RenderPass.h
@@ -538,7 +538,7 @@ protected:
 
 protected:
     globjects::ref_ptr<globjects::State>             m_stateBefore;                 ///< State applied before rendering
-    globjects::ref_ptr<globjects::State>             m_stateAfter ;                 ///< State applied after rendering
+    globjects::ref_ptr<globjects::State>             m_stateAfter;                  ///< State applied after rendering
     globjects::ref_ptr<Drawable>                     m_geometry;                    ///< Geometry rendered by the render pass
     globjects::ref_ptr<globjects::Program>           m_program;                     ///< Program used for rendering
     globjects::ref_ptr<globjects::ProgramPipeline>   m_programPipeline;             ///< Program pipeline used for rendering

--- a/source/gloperate/include/gloperate/rendering/RenderPass.h
+++ b/source/gloperate/include/gloperate/rendering/RenderPass.h
@@ -71,16 +71,41 @@ public:
     *  @return
     *    State (can be null)
     */
-    globjects::State * state() const;
+    globjects::State * stateBefore() const;
     
     /**
     *  @brief
     *    Set state that is applied before rendering
     *
-    *  @param[in] geometry
+    *  @param[in] state
+    *    State (can be null)
+    *    
+    *  @see setStateAfter()
+    */
+    void setStateBefore(globjects::State * state);
+
+    /**
+    *  @brief
+    *    Get state that is applied after rendering
+    *
+    *  @return
     *    State (can be null)
     */
-    void setState(globjects::State * state);
+    globjects::State * stateAfter() const;
+
+    /**
+    *  @brief
+    *    Set state that is applied after rendering
+    *
+    *  @param[in] state
+    *    State (can be null)
+    *    
+    *  @remarks
+    *    Use this to revert any state settings applied via setStateBefore()
+    *  
+    *  @see setStateBefore()
+    */
+    void setStateAfter(globjects::State * state);
 
     /**
     *  @brief
@@ -512,7 +537,8 @@ protected:
 
 
 protected:
-    globjects::ref_ptr<globjects::State>             m_state;                       ///< State applied before rendering
+    globjects::ref_ptr<globjects::State>             m_stateBefore;                 ///< State applied before rendering
+    globjects::ref_ptr<globjects::State>             m_stateAfter ;                 ///< State applied after rendering
     globjects::ref_ptr<Drawable>                     m_geometry;                    ///< Geometry rendered by the render pass
     globjects::ref_ptr<globjects::Program>           m_program;                     ///< Program used for rendering
     globjects::ref_ptr<globjects::ProgramPipeline>   m_programPipeline;             ///< Program pipeline used for rendering

--- a/source/gloperate/source/rendering/RenderPass.cpp
+++ b/source/gloperate/source/rendering/RenderPass.cpp
@@ -33,6 +33,11 @@ RenderPass::~RenderPass()
 void RenderPass::draw() const
 {
     bindResources();
+    
+    if (m_stateBefore)
+    {
+        m_stateBefore->apply();
+    }
 
     if (m_recordTransformFeedback)
     {
@@ -40,9 +45,6 @@ void RenderPass::draw() const
         m_recordTransformFeedback->begin(m_recordTransformFeedbackMode);
 
         gl::glEnable(gl::GL_RASTERIZER_DISCARD);
-    }
-    else
-    {
     }
 
     if (m_program)
@@ -74,16 +76,31 @@ void RenderPass::draw() const
 
         gl::glDisable(gl::GL_RASTERIZER_DISCARD);
     }
+    
+    if (m_stateAfter)
+    {
+        m_stateAfter->apply();
+    }
 }
 
-globjects::State * RenderPass::state() const
+globjects::State * RenderPass::stateBefore() const
 {
-    return m_state;
+    return m_stateBefore;
 }
 
-void RenderPass::setState(globjects::State * state)
+void RenderPass::setStateBefore(globjects::State * state)
 {
-    m_state = state;
+    m_stateBefore = state;
+}
+
+globjects::State * RenderPass::stateAfter() const
+{
+    return m_stateAfter;
+}
+
+void RenderPass::setStateAfter(globjects::State * state)
+{
+    m_stateAfter = state;
 }
 
 Drawable * RenderPass::geometry() const
@@ -453,11 +470,6 @@ void RenderPass::bindResources() const
     for (const auto & pair : m_transformFeedbackBuffers)
     {
         pair.second->bindBase(gl::GL_TRANSFORM_FEEDBACK_BUFFER, pair.first);
-    }
-
-    if (m_state)
-    {
-        m_state->apply();
     }
 }
 


### PR DESCRIPTION
This allows users of `RenderPass` to reset any state changes applied before rendering. Users must manually make sure that the states before and after match each other.

This is a quick-fix solution until optimized facilities for keeping track of and automatically revert state changes are implemented.