### PR TITLE
Fix Stage Names

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/Stage.h
+++ b/source/gloperate/include/gloperate/pipeline/Stage.h
@@ -71,7 +71,7 @@ public:
     *  @param[in] name
     *    Stage name
     */
-    Stage(Environment * environment, const std::string & className = "Stage", const std::string & name = "Stage");
+    Stage(Environment * environment, const std::string & className = "Stage", const std::string & name = "");
 
     /**
     *  @brief

--- a/source/gloperate/source/pipeline/Stage.cpp
+++ b/source/gloperate/source/pipeline/Stage.cpp
@@ -25,7 +25,7 @@ namespace gloperate
 
 
 Stage::Stage(Environment * environment, const std::string & className, const std::string & name)
-: cppexpose::Object((name == "" || name.empty()) ? className : name)
+: cppexpose::Object((name.empty()) ? className : name)
 , m_environment(environment)
 , m_alwaysProcess(false)
 {


### PR DESCRIPTION
Assume an empty name as a default, and if the name is indeed empty in constructor, use the class name.