### PR TITLE
Component specialization based on common base class

### DIFF
--- a/source/gloperate/CMakeLists.txt
+++ b/source/gloperate/CMakeLists.txt
@@ -40,8 +40,11 @@ set(headers
     ${include_path}/gloperate.h
 
     ${include_path}/base/Environment.h
+    ${include_path}/base/EnvironmentUser.h
     ${include_path}/base/System.h
     ${include_path}/base/ComponentManager.h
+    ${include_path}/base/Component.h
+    ${include_path}/base/Component.inl
     ${include_path}/base/ResourceManager.h
     ${include_path}/base/ResourceManager.inl
     ${include_path}/base/AbstractCanvas.h
@@ -156,6 +159,7 @@ set(sources
     ${source_path}/gloperate.cpp
 
     ${source_path}/base/Environment.cpp
+    ${source_path}/base/EnvironmentUser.cpp
     ${source_path}/base/System.cpp
     ${source_path}/base/ComponentManager.cpp
     ${source_path}/base/ResourceManager.cpp

--- a/source/gloperate/include/gloperate/base/AbstractLoader.h
+++ b/source/gloperate/include/gloperate/base/AbstractLoader.h
@@ -5,7 +5,10 @@
 #include <string>
 #include <vector>
 
-#include <gloperate/gloperate_api.h>
+#include <gloperate/base/EnvironmentUser.h>
+
+// Include Component<> specialization for downstream plugins
+#include <gloperate/base/Component.h>
 
 
 namespace gloperate
@@ -16,14 +19,14 @@ namespace gloperate
 *  @brief
 *    Loader base class
 */
-class GLOPERATE_API AbstractLoader 
+class GLOPERATE_API AbstractLoader : public EnvironmentUser
 {
 public:
     /**
     *  @brief
     *    Constructor
     */
-    AbstractLoader();
+    explicit AbstractLoader(Environment * environment);
 
     /**
     *  @brief

--- a/source/gloperate/include/gloperate/base/Component.h
+++ b/source/gloperate/include/gloperate/base/Component.h
@@ -1,0 +1,73 @@
+
+#pragma once
+
+
+#include <cppexpose/plugin/Component.h>
+
+
+namespace gloperate
+{
+
+
+class Environment;
+class EnvironmentUser;
+
+
+template <typename Type>
+using IsGloperateComponent = typename std::enable_if<std::is_base_of<EnvironmentUser, Type>::value>::type;
+
+}
+
+
+namespace cppexpose
+{
+
+
+/**
+*  @brief
+*    Represents a component of type inherited from EnvironmentUser
+*/
+template <typename Type>
+class TypedComponent<Type, gloperate::IsGloperateComponent<Type>> : public AbstractComponent
+{
+public:
+    TypedComponent(
+      const std::string & name
+    , const std::string & description
+    , const std::string & type
+    , const std::string & tags
+    , const std::string & icon
+    , const std::string & annotations
+    , const std::string & vendor
+    , const std::string & version);
+
+    virtual Type * createInstance(gloperate::Environment * environment) const = 0;
+};
+
+
+/**
+*  @brief
+*    Represents a concrete component of type inherited from EnvironmentUser
+*/
+template <typename Type, typename BaseType>
+class Component<Type, BaseType, gloperate::IsGloperateComponent<BaseType>> : public TypedComponent<BaseType>
+{
+public:
+    Component(
+      const std::string & name
+    , const std::string & description
+    , const std::string & type
+    , const std::string & tags
+    , const std::string & icon
+    , const std::string & annotations
+    , const std::string & vendor
+    , const std::string & version);
+
+    virtual BaseType * createInstance(gloperate::Environment * environment) const override;
+};
+
+
+} // namespace cppexpose
+
+
+#include <gloperate/base/Component.inl>

--- a/source/gloperate/include/gloperate/base/Component.inl
+++ b/source/gloperate/include/gloperate/base/Component.inl
@@ -1,0 +1,45 @@
+
+#pragma once
+
+
+namespace cppexpose
+{
+
+
+template <typename Type>
+TypedComponent<Type, gloperate::IsGloperateComponent<Type>>::TypedComponent(
+  const std::string & name
+, const std::string & description
+, const std::string & type
+, const std::string & tags
+, const std::string & icon
+, const std::string & annotations
+, const std::string & vendor
+, const std::string & version)
+: AbstractComponent(name, description, type, tags, icon, annotations, vendor, version)
+{
+}
+
+
+template <typename Type, typename BaseType>
+Component<Type, BaseType, gloperate::IsGloperateComponent<BaseType>>::Component(
+  const std::string & name
+, const std::string & description
+, const std::string & type
+, const std::string & tags
+, const std::string & icon
+, const std::string & annotations
+, const std::string & vendor
+, const std::string & version)
+: TypedComponent<BaseType>(name, description, type, tags, icon, annotations, vendor, version)
+{
+}
+
+template <typename Type, typename BaseType>
+BaseType * Component<Type, BaseType, gloperate::IsGloperateComponent<BaseType>>::createInstance(gloperate::Environment * environment) const
+{
+    return new Type(environment);
+}
+
+
+} // namespace cppexpose

--- a/source/gloperate/include/gloperate/base/EnvironmentUser.h
+++ b/source/gloperate/include/gloperate/base/EnvironmentUser.h
@@ -1,0 +1,27 @@
+
+#pragma once
+
+
+#include <gloperate/gloperate_api.h>
+
+
+namespace gloperate
+{
+
+
+class Environment;
+
+
+class GLOPERATE_API EnvironmentUser
+{
+public:
+    virtual ~EnvironmentUser();
+
+
+protected:
+    explicit EnvironmentUser(Environment * environment);
+    Environment * m_environment;
+};
+
+
+} // namespace gloperate

--- a/source/gloperate/include/gloperate/base/Loader.h
+++ b/source/gloperate/include/gloperate/base/Loader.h
@@ -28,7 +28,7 @@ public:
     *  @brief
     *    Constructor
     */
-    Loader();
+    explicit Loader(Environment * environment);
 
     /**
     *  @brief

--- a/source/gloperate/include/gloperate/base/Loader.inl
+++ b/source/gloperate/include/gloperate/base/Loader.inl
@@ -7,7 +7,8 @@ namespace gloperate
 
 
 template <typename T>
-Loader<T>::Loader()
+Loader<T>::Loader(Environment * environment)
+: AbstractLoader(environment)
 {
 }
 

--- a/source/gloperate/source/base/AbstractLoader.cpp
+++ b/source/gloperate/source/base/AbstractLoader.cpp
@@ -6,7 +6,8 @@ namespace gloperate
 {
 
 
-AbstractLoader::AbstractLoader()
+AbstractLoader::AbstractLoader(Environment * environment)
+: EnvironmentUser(environment)
 {
 }
 

--- a/source/gloperate/source/base/EnvironmentUser.cpp
+++ b/source/gloperate/source/base/EnvironmentUser.cpp
@@ -1,0 +1,20 @@
+
+#include <gloperate/base/EnvironmentUser.h>
+
+
+namespace gloperate
+{
+
+
+EnvironmentUser::EnvironmentUser(Environment * environment)
+: m_environment(environment)
+{
+}
+
+
+EnvironmentUser::~EnvironmentUser()
+{
+}
+
+
+} // namespace gloperate

--- a/source/gloperate/source/base/ResourceManager.cpp
+++ b/source/gloperate/source/base/ResourceManager.cpp
@@ -46,7 +46,7 @@ void ResourceManager::updateComponents() const
     auto loaders = m_environment->componentManager()->components<AbstractLoader>();
     for (auto component : loaders) {
         // Create loader
-        AbstractLoader * loader = component->createInstance();
+        AbstractLoader * loader = component->createInstance(m_environment);
         m_loaders.push_back(loader);
     }
 

--- a/source/plugins/gloperate-qt-loaders/QtTextureLoader.cpp
+++ b/source/plugins/gloperate-qt-loaders/QtTextureLoader.cpp
@@ -20,8 +20,8 @@ using namespace gloperate_qt;
 CPPEXPOSE_COMPONENT(QtTextureLoader, gloperate::AbstractLoader)
 
 
-QtTextureLoader::QtTextureLoader()
-: gloperate::Loader<globjects::Texture>()
+QtTextureLoader::QtTextureLoader(gloperate::Environment * environment)
+: gloperate::Loader<globjects::Texture>(environment)
 {
     // Get list of supported file formats
     QList<QByteArray> formats = QImageReader::supportedImageFormats();

--- a/source/plugins/gloperate-qt-loaders/QtTextureLoader.h
+++ b/source/plugins/gloperate-qt-loaders/QtTextureLoader.h
@@ -43,7 +43,7 @@ public:
     *  @brief
     *    Constructor
     */
-    QtTextureLoader();
+    explicit QtTextureLoader(gloperate::Environment * environment);
 
     /**
     *  @brief


### PR DESCRIPTION
Initial implementation of a component specialization based on common base class `EnvironmentUser`. This allows passing the `Environment` to components via constructor.

Todo:
- [ ] Decide if this is the way to go
- [ ] Decide on a proper name for `EnvironmentUser` class
- [ ] Apply changes to all component base types (`AbstractStorer`, `AbstractVideoExporter`, ?)?