### PR TITLE
Create and connect dynamic inputs in a single call

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/Stage.h
+++ b/source/gloperate/include/gloperate/pipeline/Stage.h
@@ -53,6 +53,26 @@ public:
 
     template <typename T>
     using Output = gloperate::Output<T>;
+    
+    // Helper class for createInput()
+    class CreateConnectedInputProxy
+    {
+        friend class Stage;
+    private:
+        CreateConnectedInputProxy(const std::string & name, Stage * stage);
+
+    public:
+        CreateConnectedInputProxy(CreateConnectedInputProxy &&) = delete;
+        ~CreateConnectedInputProxy();
+
+        template <typename T>
+        Input<T> * operator<<(Slot<T> & source);
+
+    private:
+        std::string m_name;
+        Stage * m_stage;
+        int m_createdCount;
+    };
 
 
 public:
@@ -305,6 +325,24 @@ public:
     *  @brief
     *    Create dynamic input connected to a source
     *
+    *  @param[in] name
+    *    Name of the input
+    *
+    *  @return
+    *    A proxy object that defers the actual creation to the operator<<
+    *
+    *  @remarks
+    *    The operator<< must be called exactly once on the returned proxy object.
+    *    
+    *    createInput("somename") << someOutput; behaves exactly like
+    *    createConnectedInput("somename", someOutput);
+    */
+    CreateConnectedInputProxy createInput(const std::string & name);
+
+    /**
+    *  @brief
+    *    Create dynamic input connected to a source
+    *
     *  @tparam T
     *    Type of the input
     *  @param[in] name
@@ -316,36 +354,10 @@ public:
     *    Input, nullptr on error
     *
     *  @remarks
-    *    Creates a dynamic input connect to source and transfers ownership to the stage.
-    *    
-    *    Two separate overloads for Input and Output source are required to correctly
-    *    deduce T from both Input<T> and Output<T>.
+    *    Creates a dynamic input connected to source and transfers ownership to the stage.
     */
     template <typename T>
-    Input<T> * createInput(const std::string & name, Input<T> & source);
-
-    /**
-    *  @brief
-    *    Create dynamic input connected to a source
-    *
-    *  @tparam T
-    *    Type of the input
-    *  @param[in] name
-    *    Name of the input
-    *  @param[in] source
-    *    The output to connect the new input to
-    *
-    *  @return
-    *    Input, nullptr on error
-    *
-    *  @remarks
-    *    Creates a dynamic input connect to source and transfers ownership to the stage.
-    *    
-    *    Two separate overloads for Input and Output source are required to correctly
-    *    deduce T from both Input<T> and Output<T>.
-    */
-    template <typename T>
-    Input<T> * createInput(const std::string & name, Output<T> & source);
+    Input<T> * createConnectedInput(const std::string & name, Slot<T> & source);
 
     /**
     *  @brief

--- a/source/gloperate/include/gloperate/pipeline/Stage.h
+++ b/source/gloperate/include/gloperate/pipeline/Stage.h
@@ -303,6 +303,52 @@ public:
 
     /**
     *  @brief
+    *    Create dynamic input connected to a source
+    *
+    *  @tparam T
+    *    Type of the input
+    *  @param[in] name
+    *    Name of the input
+    *  @param[in] source
+    *    The input to connect the new input to
+    *
+    *  @return
+    *    Input, nullptr on error
+    *
+    *  @remarks
+    *    Creates a dynamic input connect to source and transfers ownership to the stage.
+    *    
+    *    Two separate overloads for Input and Output source are required to correctly
+    *    deduce T from both Input<T> and Output<T>.
+    */
+    template <typename T>
+    Input<T> * createInput(const std::string & name, Input<T> & source);
+
+    /**
+    *  @brief
+    *    Create dynamic input connected to a source
+    *
+    *  @tparam T
+    *    Type of the input
+    *  @param[in] name
+    *    Name of the input
+    *  @param[in] source
+    *    The output to connect the new input to
+    *
+    *  @return
+    *    Input, nullptr on error
+    *
+    *  @remarks
+    *    Creates a dynamic input connect to source and transfers ownership to the stage.
+    *    
+    *    Two separate overloads for Input and Output source are required to correctly
+    *    deduce T from both Input<T> and Output<T>.
+    */
+    template <typename T>
+    Input<T> * createInput(const std::string & name, Output<T> & source);
+
+    /**
+    *  @brief
     *    Add input
     *
     *  @param[in] input

--- a/source/gloperate/include/gloperate/pipeline/Stage.inl
+++ b/source/gloperate/include/gloperate/pipeline/Stage.inl
@@ -42,6 +42,24 @@ Input<T> * Stage::createInput(const std::string & name, const T & defaultValue)
 }
 
 template <typename T>
+Input<T> * Stage::createInput(const std::string & name, Input<T> & source)
+{
+    auto input = createInput<T>(name);
+    input->connect(&source);
+
+    return input;
+}
+
+template <typename T>
+Input<T> * Stage::createInput(const std::string & name, Output<T> & source)
+{
+    auto input = createInput<T>(name);
+    input->connect(&source);
+
+    return input;
+}
+
+template <typename T>
 std::vector<Output<T> *> Stage::outputs() const
 {
     auto result = std::vector<Output<T> *>{};

--- a/source/gloperate/include/gloperate/pipeline/Stage.inl
+++ b/source/gloperate/include/gloperate/pipeline/Stage.inl
@@ -13,6 +13,13 @@ namespace gloperate
 
 
 template <typename T>
+Input<T> * Stage::CreateConnectedInputProxy::operator<<(Slot<T> & source)
+{
+    ++m_createdCount;
+    return m_stage->createConnectedInput(m_name, source);
+}
+
+template <typename T>
 std::vector<Input<T> *> Stage::inputs() const
 {
     auto result = std::vector<Input<T> *>{};
@@ -42,16 +49,7 @@ Input<T> * Stage::createInput(const std::string & name, const T & defaultValue)
 }
 
 template <typename T>
-Input<T> * Stage::createInput(const std::string & name, Input<T> & source)
-{
-    auto input = createInput<T>(name);
-    input->connect(&source);
-
-    return input;
-}
-
-template <typename T>
-Input<T> * Stage::createInput(const std::string & name, Output<T> & source)
+Input<T> * Stage::createConnectedInput(const std::string & name, Slot<T> & source)
 {
     auto input = createInput<T>(name);
     input->connect(&source);

--- a/source/gloperate/source/pipeline/Stage.cpp
+++ b/source/gloperate/source/pipeline/Stage.cpp
@@ -24,6 +24,18 @@ namespace gloperate
 {
 
 
+Stage::CreateConnectedInputProxy::CreateConnectedInputProxy(const std::string & name, Stage * stage)
+: m_name(name)
+, m_stage(stage)
+, m_createdCount(0)
+{
+}
+
+Stage::CreateConnectedInputProxy::~CreateConnectedInputProxy()
+{
+    assert(m_createdCount == 1);
+}
+
 Stage::Stage(Environment * environment, const std::string & className, const std::string & name)
 : cppexpose::Object((name.empty()) ? className : name)
 , m_environment(environment)
@@ -158,6 +170,13 @@ AbstractSlot * Stage::input(const std::string & name)
 
     return m_inputsMap.at(name);
 }
+
+
+Stage::CreateConnectedInputProxy Stage::createInput(const std::string & name)
+{
+    return { name, this };
+}
+
 
 void Stage::addInput(AbstractSlot * input, cppexpose::PropertyOwnership ownership)
 {

--- a/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
+++ b/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
@@ -53,8 +53,8 @@ ShaderDemoPipeline::ShaderDemoPipeline(Environment * environment, const std::str
 
     // Basic program stage
     addStage(m_programStage);
-    *(m_programStage->createInput<cppassist::FilePath>("shader1")) << shader1;
-    *(m_programStage->createInput<globjects::Shader *>("shader2")) << m_shaderStage->shader;
+    m_programStage->createInput("shader1", shader1);
+    m_programStage->createInput("shader2", m_shaderStage->shader);
 
     // Framebuffer stage for spinning rect
     addStage(m_framebufferStage);

--- a/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
+++ b/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
@@ -53,8 +53,8 @@ ShaderDemoPipeline::ShaderDemoPipeline(Environment * environment, const std::str
 
     // Basic program stage
     addStage(m_programStage);
-    m_programStage->createInput("shader1", shader1);
-    m_programStage->createInput("shader2", m_shaderStage->shader);
+    m_programStage->createInput("shader1") << shader1;
+    m_programStage->createInput("shader2") << m_shaderStage->shader;
 
     // Framebuffer stage for spinning rect
     addStage(m_framebufferStage);


### PR DESCRIPTION
This adds corresponding `Stage::createInput` overloads. Simplifies creating dynamic inputs from
```
*(m_programStage->createInput<cppassist::FilePath>("shader1")) << shader1;
*(m_programStage->createInput<globjects::Shader *>("shader2")) << m_shaderStage->shader;
```
to
```
m_programStage->createInput("shader1", shader1);
m_programStage->createInput("shader2", m_shaderStage->shader);
```

I considered adding similar overloads for `createOutput` for symmetry; however, I don't really see the use case for creating directly connected dynamic outputs?

Sorry for not unifying this with #254.