### PR TITLE
Transparent Slot::operator-> for pointers

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/Slot.h
+++ b/source/gloperate/include/gloperate/pipeline/Slot.h
@@ -139,8 +139,8 @@ public:
     *  @return
     *    Pointer to the stored data object (non-pointer T) or the stored pointer (pointer T)
     */
-    typename DereferenceHelper<T>::Pointer operator->();
-    typename DereferenceHelper<const T>::Pointer operator->() const;
+    auto operator->() -> typename DereferenceHelper<T>::Pointer;
+    auto operator->() const -> typename DereferenceHelper<const T>::Pointer;
     //@}
 
     // Virtual AbstractSlot interface

--- a/source/gloperate/include/gloperate/pipeline/Slot.h
+++ b/source/gloperate/include/gloperate/pipeline/Slot.h
@@ -26,6 +26,26 @@ namespace gloperate
 template <typename T>
 class Slot : public cppexpose::DirectValue<T, AbstractSlot>
 {
+protected:
+    //@{
+    /**
+    * @see operator->()
+    */
+    template <typename U>
+    struct DereferenceHelper
+    {
+        using Pointer = U *;
+        static Pointer pointer(U * value);
+    };
+    template <typename U>
+    struct DereferenceHelper<U *>
+    {
+        using Pointer = U *;
+        static Pointer pointer(U ** value);
+    };
+    //@}
+
+
 public:
     cppexpose::Signal<const T &> valueChanged;      ///< Called when the value has been changed
     cppexpose::Signal<>          connectionChanged; ///< Called when the connection has been changed
@@ -117,10 +137,10 @@ public:
     *    Dereference pointer operator
     *
     *  @return
-    *    Pointer to the stored data object (never null)
+    *    Pointer to the stored data object (non-pointer T) or the stored pointer (pointer T)
     */
-    T * operator->();
-    const T * operator->() const;
+    typename DereferenceHelper<T>::Pointer operator->();
+    const typename DereferenceHelper<T>::Pointer operator->() const;
     //@}
 
     // Virtual AbstractSlot interface

--- a/source/gloperate/include/gloperate/pipeline/Slot.h
+++ b/source/gloperate/include/gloperate/pipeline/Slot.h
@@ -140,7 +140,7 @@ public:
     *    Pointer to the stored data object (non-pointer T) or the stored pointer (pointer T)
     */
     typename DereferenceHelper<T>::Pointer operator->();
-    const typename DereferenceHelper<T>::Pointer operator->() const;
+    typename DereferenceHelper<const T>::Pointer operator->() const;
     //@}
 
     // Virtual AbstractSlot interface

--- a/source/gloperate/include/gloperate/pipeline/Slot.inl
+++ b/source/gloperate/include/gloperate/pipeline/Slot.inl
@@ -11,6 +11,20 @@
 namespace gloperate
 {
 
+template <typename T>
+template <typename U>
+typename Slot<T>::DereferenceHelper<U>::Pointer Slot<T>::DereferenceHelper<U>::pointer(U * value)
+{
+    return value;
+}
+
+template <typename T>
+template <typename U>
+typename Slot<T>::DereferenceHelper<U *>::Pointer Slot<T>::DereferenceHelper<U*>::pointer(U ** value)
+{
+    return *value;
+}
+
 
 template <typename T>
 Slot<T>::Slot(SlotType slotType, const std::string & name, Stage * parent, const T & value)
@@ -89,15 +103,15 @@ const T & Slot<T>::operator*() const
 }
 
 template <typename T>
-T * Slot<T>::operator->()
+typename Slot<T>::DereferenceHelper<T>::Pointer Slot<T>::operator->()
 {
-    return this->ptr();
+    return DereferenceHelper<T>::pointer(this->ptr());
 }
 
 template <typename T>
-const T * Slot<T>::operator->() const
+const typename Slot<T>::DereferenceHelper<T>::Pointer Slot<T>::operator->() const
 {
-    return this->ptr();
+    return DereferenceHelper<T>::pointer(this->ptr());
 }
 
 template <typename T>

--- a/source/gloperate/include/gloperate/pipeline/Slot.inl
+++ b/source/gloperate/include/gloperate/pipeline/Slot.inl
@@ -103,13 +103,13 @@ const T & Slot<T>::operator*() const
 }
 
 template <typename T>
-typename Slot<T>::DereferenceHelper<T>::Pointer Slot<T>::operator->()
+auto Slot<T>::operator->() -> typename DereferenceHelper<T>::Pointer
 {
     return DereferenceHelper<T>::pointer(this->ptr());
 }
 
 template <typename T>
-typename Slot<T>::DereferenceHelper<const T>::Pointer Slot<T>::operator->() const
+auto Slot<T>::operator->() const -> typename DereferenceHelper<const T>::Pointer
 {
     return DereferenceHelper<const T>::pointer(this->ptr());
 }

--- a/source/gloperate/include/gloperate/pipeline/Slot.inl
+++ b/source/gloperate/include/gloperate/pipeline/Slot.inl
@@ -109,9 +109,9 @@ typename Slot<T>::DereferenceHelper<T>::Pointer Slot<T>::operator->()
 }
 
 template <typename T>
-const typename Slot<T>::DereferenceHelper<T>::Pointer Slot<T>::operator->() const
+typename Slot<T>::DereferenceHelper<const T>::Pointer Slot<T>::operator->() const
 {
-    return DereferenceHelper<T>::pointer(this->ptr());
+    return DereferenceHelper<const T>::pointer(this->ptr());
 }
 
 template <typename T>

--- a/source/gloperate/source/stages/base/MixerStage.cpp
+++ b/source/gloperate/source/stages/base/MixerStage.cpp
@@ -116,7 +116,7 @@ void MixerStage::onProcess(AbstractGLContext *)
     // Bind texture
     if (*texture) {
         gl::glActiveTexture(gl::GL_TEXTURE0 + 0);
-        (*texture)->bind();
+        texture->bind();
     }
 
     // Draw screen-aligned quad
@@ -127,12 +127,12 @@ void MixerStage::onProcess(AbstractGLContext *)
 
     // Unbind texture
     if (*texture) {
-        (*texture)->unbind();
+        texture->unbind();
     }
 
     // Unbind FBO, bind default FBO
     if (*targetFBO) {
-        (*targetFBO)->unbind(gl::GL_FRAMEBUFFER);
+        targetFBO->unbind(gl::GL_FRAMEBUFFER);
         globjects::Framebuffer::defaultFBO()->bind(gl::GL_FRAMEBUFFER);
     }
 

--- a/source/gloperate/source/stages/base/SplitStage.cpp
+++ b/source/gloperate/source/stages/base/SplitStage.cpp
@@ -104,7 +104,7 @@ void SplitStage::onProcess(AbstractGLContext *)
 
     // Bind texture #1
     if (*texture1) {
-        (*texture1)->bindActive(0);
+        texture1->bindActive(0);
     }
 
     // Draw screen-aligned quad
@@ -115,7 +115,7 @@ void SplitStage::onProcess(AbstractGLContext *)
 
     // Unbind texture #1
     if (*texture1) {
-        (*texture1)->unbindActive(0);
+        texture1->unbindActive(0);
     }
 
     // Set viewport for texture #2
@@ -123,7 +123,7 @@ void SplitStage::onProcess(AbstractGLContext *)
 
     // Bind texture #2
     if (*texture2) {
-        (*texture2)->bindActive(0);
+        texture2->bindActive(0);
     }
 
     // Draw screen-aligned quad
@@ -134,7 +134,7 @@ void SplitStage::onProcess(AbstractGLContext *)
 
     // Unbind texture #2
     if (*texture2) {
-        (*texture2)->unbindActive(0);
+        texture2->unbindActive(0);
     }
 
     // Restore OpenGL states
@@ -143,7 +143,7 @@ void SplitStage::onProcess(AbstractGLContext *)
 
     // Unbind FBO, bind default FBO
     if (*targetFBO) {
-        (*targetFBO)->unbind(gl::GL_FRAMEBUFFER);
+        targetFBO->unbind(gl::GL_FRAMEBUFFER);
         globjects::Framebuffer::defaultFBO()->bind(gl::GL_FRAMEBUFFER);
     }
 


### PR DESCRIPTION
Specialize the return type of `Slot<T>::operator->` to return a pointer-to-object even if T is itself a pointer. This simplifies calling members on a Slot's value. Example:
```
Input<globjects::Texture *> myInput;

// current
(*myInput)->bind();

// proposed
myInput->bind();
```

Additional specializations can be added for smart pointers.