### PR TITLE
Remove non-const Slot::operator*

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/Input.h
+++ b/source/gloperate/include/gloperate/pipeline/Input.h
@@ -27,7 +27,7 @@ public:
     *    Property name
     *  @param[in] parent
     *    Parent stage (must NOT be null!)
-    *  @param[in] value
+    *  @param[in] defaultValue
     *    Default value
     *
     *  @remarks
@@ -43,7 +43,7 @@ public:
     *
     *  @param[in] name
     *    Property name
-    *  @param[in] value
+    *  @param[in] defaultValue
     *    Default value
     *
     *  @remarks
@@ -58,6 +58,23 @@ public:
     *    Destructor
     */
     virtual ~Input();
+
+    /**
+    *  @brief
+    *    Set value
+    *
+    *  @tparam[in] U
+    *    Type of the assigned value. Must be implicitly convertible to T.
+    *  @param[in] value
+    *    Value
+    *    
+    *  @remarks
+    *    Has the same effect as calling setValue().
+    *    
+    *  @see setValue()
+    */
+    template <typename U, typename Enable = typename std::enable_if<std::is_convertible<U, T>::value>::type>
+    Input<T> & operator=(const U & value);
 
 
 protected:

--- a/source/gloperate/include/gloperate/pipeline/Input.inl
+++ b/source/gloperate/include/gloperate/pipeline/Input.inl
@@ -67,5 +67,14 @@ void Input<T>::onValueChanged(const T & value)
     this->m_cycleGuard[this_id] = false;
 }
 
+template <typename T>
+template <typename U, typename Enable = typename std::enable_if<std::is_convertible<U, T>::value>::type>
+Input<T> & Input<T>::operator=(const U & value)
+{
+    setValue(value);
+
+    return *this;
+}
+
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/Output.h
+++ b/source/gloperate/include/gloperate/pipeline/Output.h
@@ -27,7 +27,7 @@ public:
     *    Property name
     *  @param[in] parent
     *    Parent stage (must NOT be null!)
-    *  @param[in] value
+    *  @param[in] defaultValue
     *    Default value
     *
     *  @remarks
@@ -43,7 +43,7 @@ public:
     *
     *  @param[in] name
     *    Property name
-    *  @param[in] value
+    *  @param[in] defaultValue
     *    Default value
     *
     *  @remarks
@@ -58,6 +58,23 @@ public:
     *    Destructor
     */
     virtual ~Output();
+
+    /**
+    *  @brief
+    *    Set value
+    *
+    *  @tparam[in] U
+    *    Type of the assigned value. Must be implicitly convertible to T.
+    *  @param[in] value
+    *    Value
+    *
+    *  @remarks
+    *    Has the same effect as calling setValue().
+    *
+    *  @see setValue()
+    */
+    template <typename U, typename Enable = typename std::enable_if<std::is_convertible<U, T>::value>::type>
+    Output<T> & operator=(const U & value);
 
 
 protected:

--- a/source/gloperate/include/gloperate/pipeline/Output.inl
+++ b/source/gloperate/include/gloperate/pipeline/Output.inl
@@ -79,5 +79,14 @@ void Output<T>::onValueChanged(const T & value)
     this->m_cycleGuard[this_id] = false;
 }
 
+template <typename T>
+template <typename U, typename Enable = typename std::enable_if<std::is_convertible<U, T>::value>::type>
+Output<T> & Output<T>::operator=(const U & value)
+{
+    setValue(value);
+
+    return *this;
+}
+
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/Slot.h
+++ b/source/gloperate/include/gloperate/pipeline/Slot.h
@@ -117,9 +117,7 @@ public:
     *    Reference to this slot
     */
     Slot<T> & operator<<(Slot<T> & source);
-    //@}
 
-    //@{
     /**
     *  @brief
     *    Dereference pointer operator
@@ -127,7 +125,6 @@ public:
     *  @return
     *    Reference to the stored data object
     */
-    T & operator*();
     const T & operator*() const;
     //@}
 

--- a/source/gloperate/include/gloperate/pipeline/Slot.inl
+++ b/source/gloperate/include/gloperate/pipeline/Slot.inl
@@ -91,12 +91,6 @@ Slot<T> & Slot<T>::operator<<(Slot<T> & source)
 }
 
 template <typename T>
-T & Slot<T>::operator*()
-{
-    return *this->ptr();
-}
-
-template <typename T>
 const T & Slot<T>::operator*() const
 {
     return *this->ptr();

--- a/source/gloperate/source/stages/demos/DemoPipeline.cpp
+++ b/source/gloperate/source/stages/demos/DemoPipeline.cpp
@@ -42,8 +42,8 @@ DemoPipeline::DemoPipeline(Environment * environment, const std::string & name)
     std::string dataPath = gloperate::dataPath();
 
     // Setup parameters
-    *texture = dataPath + "/gloperate/textures/gloperate-logo.png";
-    *rotate  = true;
+    texture = dataPath + "/gloperate/textures/gloperate-logo.png";
+    rotate  = true;
     rotate.valueChanged.connect(this, &DemoPipeline::onRotateChanged);
 
     // Texture loader stage

--- a/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
+++ b/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
@@ -38,10 +38,10 @@ ShaderDemoPipeline::ShaderDemoPipeline(Environment * environment, const std::str
     std::string dataPath = gloperate::dataPath();
 
     // Setup parameters
-    *shader1 = dataPath + "/gloperate/shaders/Demo/Demo.frag";
-    *shader2 = dataPath + "/gloperate/shaders/Demo/Demo.vert";
+    shader1 = dataPath + "/gloperate/shaders/Demo/Demo.frag";
+    shader2 = dataPath + "/gloperate/shaders/Demo/Demo.vert";
 
-    *texture = dataPath + "/gloperate/textures/gloperate-logo.png";
+    texture = dataPath + "/gloperate/textures/gloperate-logo.png";
 
     // Texture loader stage
     addStage(m_textureLoadStage);


### PR DESCRIPTION
and add value assignment operator for Input & Output.

Assignment operator must be implemented separately for Input and Output, as their implicitly declared copy assignment operator hides any base class (Slot) assignment operator.