### PR TITLE
Compile fixes for MSVC

### DIFF
--- a/source/gloperate-text/include/gloperate-text/GlyphRenderer.h
+++ b/source/gloperate-text/include/gloperate-text/GlyphRenderer.h
@@ -30,6 +30,8 @@ public:
     explicit GlyphRenderer(globjects::Program * program);
     virtual ~GlyphRenderer();
 
+    GlyphRenderer & operator=(const GlyphRenderer &) = delete;
+
     globjects::Program * program();
     const globjects::Program * program() const;
 

--- a/source/gloperate-text/include/gloperate-text/GlyphVertexCloud.h
+++ b/source/gloperate-text/include/gloperate-text/GlyphVertexCloud.h
@@ -48,6 +48,8 @@ public:
     GlyphVertexCloud();
     virtual ~GlyphVertexCloud();
 
+    GlyphVertexCloud & operator=(const GlyphVertexCloud &) = delete;
+
     const globjects::Texture * texture() const;
     void setTexture(globjects::Texture * texture);
 


### PR DESCRIPTION
Required, as `dllexport` causes generation of implicit copy/move constructors/assignment operators, which requires the full definition of classes stored in a `ref_ptr`/`unique_ptr`, whose include should be avoided in header files.