### PR TITLE
Make keyboard input usable

### DIFF
--- a/source/gloperate-glfw/source/RenderWindow.cpp
+++ b/source/gloperate-glfw/source/RenderWindow.cpp
@@ -110,9 +110,15 @@ void RenderWindow::onPaint(PaintEvent &)
 
 void RenderWindow::onKeyPress(KeyEvent & event)
 {
+    // Skip auto-repeated key events
+    if (event.action() == GLFW_REPEAT)
+    {
+        return;
+    }
+
     if (event.key() == GLFW_KEY_F11)
     {
-      setFullscreen(!isFullscreen());
+        setFullscreen(!isFullscreen());
     }
 
     m_canvas->onKeyPress(

--- a/source/gloperate-qt/source/base/RenderWindow.cpp
+++ b/source/gloperate-qt/source/base/RenderWindow.cpp
@@ -76,6 +76,12 @@ void RenderWindow::onPaint()
 
 void RenderWindow::keyPressEvent(QKeyEvent * event)
 {
+    // Skip auto-repeated key events
+    if (event->isAutoRepeat())
+    {
+        return;
+    }
+
     m_canvas->onKeyPress(
         fromQtKeyCode(event->key(), event->modifiers()),
         fromQtModifiers(event->modifiers())
@@ -84,6 +90,12 @@ void RenderWindow::keyPressEvent(QKeyEvent * event)
 
 void RenderWindow::keyReleaseEvent(QKeyEvent * event)
 {
+    // Skip auto-repeated key events
+    if (event->isAutoRepeat())
+    {
+        return;
+    }
+
     m_canvas->onKeyRelease(
         fromQtKeyCode(event->key(), event->modifiers()),
         fromQtModifiers(event->modifiers())

--- a/source/gloperate-qtquick/source/RenderItem.cpp
+++ b/source/gloperate-qtquick/source/RenderItem.cpp
@@ -177,6 +177,12 @@ void RenderItem::geometryChanged(const QRectF & newGeometry, const QRectF & oldG
 
 void RenderItem::keyPressEvent(QKeyEvent * event)
 {
+    // Skip auto-repeated key events
+    if (event->isAutoRepeat())
+    {
+        return;
+    }
+
     if (m_canvas)
     {
         m_canvas->onKeyPress(
@@ -188,6 +194,12 @@ void RenderItem::keyPressEvent(QKeyEvent * event)
 
 void RenderItem::keyReleaseEvent(QKeyEvent * event)
 {
+    // Skip auto-repeated key events
+    if (event->isAutoRepeat())
+    {
+        return;
+    }
+
     if (m_canvas)
     {
         m_canvas->onKeyRelease(

--- a/source/gloperate/include/gloperate/input/ButtonEvent.h
+++ b/source/gloperate/include/gloperate/input/ButtonEvent.h
@@ -20,26 +20,38 @@ public:
     *    The type of the ButtonEvent (must be either of InputEvent::Type::ButtonPress or InputEvent::Type::ButtonRelease)
     *  @param[in] dispatchingDevice
     *    Pointer to the device that generated the event (must NOT be null)
-    *  @param[in] description
-    *    A string decribing the pressed button
+    *  @param[in] key
+    *    The key code
+    *  @param[in] modifier
+    *    Th active modifiers
     */
-    ButtonEvent(Type type, AbstractDevice * dispatchingDevice, const std::string & description);
+    ButtonEvent(Type type, AbstractDevice * dispatchingDevice, int key, int modifier);
 
     /**
     *  @brief
-    *    A getter for the description of the event
-    *
+    *    Get key code
+    *    
     *  @return
-    *    A string decribing the pressed button
+    *    The key code
     */
-    std::string description() const;
+    int key() const;
+
+    /**
+    *  @brief
+    *    Get modifier
+    *    
+    *  @return
+    *    The modifier
+    */
+    int modifier() const;
+
 
     // Virtual InputEvent interface
     virtual std::string asString() const override;
 
-
 protected:
-    std::string m_description;
+    int         m_key;
+    int         m_modifier;
 };
 
 

--- a/source/gloperate/source/input/ButtonEvent.cpp
+++ b/source/gloperate/source/input/ButtonEvent.cpp
@@ -6,17 +6,31 @@ namespace gloperate
 {
 
 
-ButtonEvent::ButtonEvent(Type type, AbstractDevice * dispatchingDevice, const std::string & description)
+ButtonEvent::ButtonEvent(Type type, AbstractDevice * dispatchingDevice, int key, int modifier)
 : InputEvent(type, dispatchingDevice)
-, m_description(description)
+, m_key(key)
+, m_modifier(modifier)
 {
     assert(type == Type::ButtonPress ||
            type == Type::ButtonRelease);
 }
 
+
+int ButtonEvent::key() const
+{
+    return m_key;
+}
+
+
+int ButtonEvent::modifier() const
+{
+    return m_modifier;
+}
+
+
 std::string ButtonEvent::asString() const
 {
-    return m_description;
+    return type() == Type::ButtonPress ? "Press " : "Release " + std::to_string(m_key) + ":" + std::to_string(m_modifier);
 }
 
 

--- a/source/gloperate/source/input/KeyboardDevice.cpp
+++ b/source/gloperate/source/input/KeyboardDevice.cpp
@@ -23,7 +23,8 @@ void KeyboardDevice::keyPress(int key, int modifier)
     auto inputEvent = new ButtonEvent{
         InputEvent::Type::ButtonPress,
         this,
-        std::to_string(key) + ":" + std::to_string(modifier)
+        key,
+        modifier
     };
 
     m_inputManager->onEvent(inputEvent);
@@ -32,9 +33,10 @@ void KeyboardDevice::keyPress(int key, int modifier)
 void KeyboardDevice::keyRelease(int key, int modifier)
 {
     auto inputEvent = new ButtonEvent{
-        InputEvent::Type::ButtonPress,
+        InputEvent::Type::ButtonRelease,
         this,
-        std::to_string(key) + ":" + std::to_string(modifier)
+        key,
+        modifier
     };
 
     m_inputManager->onEvent(inputEvent);


### PR DESCRIPTION
- Identify `ButtonEvent`s using key code and modifier instead of a description string
- Ignore auto-repeated key presses