### PR TITLE
Add TimeManager::activated signal to resume time tracking after a pause

### DIFF
--- a/source/gloperate-qt/source/base/UpdateManager.cpp
+++ b/source/gloperate-qt/source/base/UpdateManager.cpp
@@ -19,6 +19,9 @@ UpdateManager::UpdateManager(gloperate::Environment * environment)
         this, &UpdateManager::onTimer
     );
 
+    // Connect wake signal
+    environment->timeManager()->activated.connect(this, &UpdateManager::wakeTimer);
+
     // Setup timer
     m_timer.setSingleShot(false);
     m_timer.start(0);

--- a/source/gloperate/include/gloperate/base/TimeManager.h
+++ b/source/gloperate/include/gloperate/base/TimeManager.h
@@ -31,6 +31,18 @@ class GLOPERATE_API TimeManager : public cppexpose::Object
 public:
     /**
     *  @brief
+    *    Fired when any timer was activated after no timer was active.
+    *    
+    *  @remarks
+    *    Platform backends can connect to this signal to resume time
+    *    tracking after a pause (e.g., when update() returned false)
+    */
+    cppexpose::Signal<> activated;
+
+
+public:
+    /**
+    *  @brief
     *    Constructor
     *
     *  @param[in] environment

--- a/source/gloperate/source/base/TimeManager.cpp
+++ b/source/gloperate/source/base/TimeManager.cpp
@@ -88,6 +88,7 @@ void TimeManager::activateTimer()
     if (m_activeTimers == 0)
     {
         m_clock.reset();
+        activated();
     }
 
     m_activeTimers++;


### PR DESCRIPTION
This is only a temporary solution. A definite solution should be developed in the context of #219, #187 and #170.