### PR TITLE
Fix ScreenAlignedTriangle VAO size

### DIFF
--- a/source/gloperate/source/rendering/ScreenAlignedTriangle.cpp
+++ b/source/gloperate/source/rendering/ScreenAlignedTriangle.cpp
@@ -37,7 +37,7 @@ ScreenAlignedTriangle::ScreenAlignedTriangle()
     m_drawable->setAttributeBindingFormat(0, 2, gl::GL_FLOAT, gl::GL_FALSE, 0);
     m_drawable->enableAttributeBinding(0);
 
-    m_drawable->setSize(4);
+    m_drawable->setSize(3);
 }
 
 ScreenAlignedTriangle::~ScreenAlignedTriangle()


### PR DESCRIPTION
Last time I checked, a triangle had **3** vertices...

VBO was correct, though.