### PR TITLE
Fix RenderPass initialization

### DIFF
--- a/source/gloperate/include/gloperate/rendering/RenderPass.h
+++ b/source/gloperate/include/gloperate/rendering/RenderPass.h
@@ -241,7 +241,7 @@ public:
     *  @brief
     *    Set program pipeline used by the render pass
     *
-    *  @param[in] program
+    *  @param[in] programPipeline
     *    Program pipeline (can be null)
     *
     *  @notes
@@ -267,7 +267,7 @@ public:
     *  @brief
     *    Get texture used by the render pass
     *
-    *  @param[in] index
+    *  @param[in] activeTextureIndex
     *    Texture index (does not need to be continuous)
     *
     *  @return
@@ -294,7 +294,7 @@ public:
     *  @brief
     *    Set texture used by the render pass
     *
-    *  @param[in] index
+    *  @param[in] activeTextureIndex
     *    Texture index (does not need to be continuous)
     *  @param[in] texture
     *    Texture (must NOT be null!)

--- a/source/gloperate/source/rendering/RenderPass.cpp
+++ b/source/gloperate/source/rendering/RenderPass.cpp
@@ -7,7 +7,6 @@
 #include <globjects/Texture.h>
 #include <globjects/Sampler.h>
 #include <globjects/Buffer.h>
-#include <globjects/VertexArray.h>
 #include <globjects/Program.h>
 #include <globjects/ProgramPipeline.h>
 #include <globjects/TransformFeedback.h>
@@ -21,7 +20,14 @@ namespace gloperate
 
 
 RenderPass::RenderPass()
-: m_recordTransformFeedbackMode(gl::GL_POINTS)
+: m_stateBefore(nullptr)
+, m_stateAfter(nullptr)
+, m_geometry(nullptr)
+, m_program(nullptr)
+, m_programPipeline(nullptr)
+, m_recordTransformFeedback(nullptr)
+, m_recordTransformFeedbackMode(gl::GL_POINTS)
+, m_drawTransformFeedback(nullptr)
 , m_drawTransformFeedbackMode(gl::GL_POINTS)
 {
 }


### PR DESCRIPTION
... and some parameter names in documentation.

Missing initialization crashes the program, as RenderPass tries to access random memory.