### PR TITLE
Increase debug log level for Pipeline & remove call to setVerbosityLevel

### DIFF
--- a/source/gloperate/source/pipeline/Pipeline.cpp
+++ b/source/gloperate/source/pipeline/Pipeline.cpp
@@ -282,7 +282,7 @@ void Pipeline::onProcess(AbstractGLContext * context)
     for (auto stage : m_stages)
     {
         if (stage->needsProcessing()) {
-            debug() << "Process stage " << stage->name();
+            debug(1) << "Process stage " << stage->name();
             stage->process(context);
         }
     }

--- a/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
+++ b/source/gloperate/source/stages/demos/ShaderDemoPipeline.cpp
@@ -37,8 +37,6 @@ ShaderDemoPipeline::ShaderDemoPipeline(Environment * environment, const std::str
 , m_rasterizationStage(cppassist::make_unique<RasterizationStage>(environment, "RasterizationStage"))
 , m_mixerStage(cppassist::make_unique<MixerStage>(environment, "MixerStage"))
 {
-    setVerbosityLevel(cppassist::LogMessage::Debug);
-
     // Get data path
     std::string dataPath = gloperate::dataPath();
 


### PR DESCRIPTION
Logging every processed Stage produces a lot of output that is rarely necessary.

Wasn't there a ticket somewhere for creating a logging style guide? Currently, logging seems a bit random...