### PR TITLE
Compile fix for macOS

### DIFF
--- a/source/gloperate-glfw/source/GLContextFactory.cpp
+++ b/source/gloperate-glfw/source/GLContextFactory.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<gloperate::AbstractGLContext> GLContextFactory::createContext(co
     // Handle swap behavior
     context->updateSwapBehavior(format.swapBehavior());
 
-    return context;
+    return std::move(context);
 }
 
 void GLContextFactory::initializeGLFWState(const gloperate::GLContextFormat & format)

--- a/source/gloperate-qtquick/source/Utils.cpp
+++ b/source/gloperate-qtquick/source/Utils.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<gloperate::AbstractCanvas> Utils::createCanvas(gloperate::Enviro
 {
     auto canvas = cppassist::make_unique<gloperate::Canvas>(environment);
     canvas->setRenderStage(std::move(renderStage));
-    return canvas;
+    return std::move(canvas);
 }
 
 


### PR DESCRIPTION
AppleClang can't automatically upcast a unique_ptr during return.