### PR TITLE
Remove stages back-to-front in Pipeline destructor

### DIFF
--- a/source/gloperate/source/pipeline/Pipeline.cpp
+++ b/source/gloperate/source/pipeline/Pipeline.cpp
@@ -40,6 +40,10 @@ Pipeline::Pipeline(Environment * environment, const std::string & className, con
 
 Pipeline::~Pipeline()
 {
+    while (!m_stages.empty())
+    {
+        removeStage(m_stages.back());
+    }
 }
 
 const std::vector<Stage *> & Pipeline::stages() const

--- a/source/gloperate/source/pipeline/Pipeline.cpp
+++ b/source/gloperate/source/pipeline/Pipeline.cpp
@@ -40,6 +40,7 @@ Pipeline::Pipeline(Environment * environment, const std::string & className, con
 
 Pipeline::~Pipeline()
 {
+    // Do not use iterators here, as removeStage modifies m_stages
     while (!m_stages.empty())
     {
         removeStage(m_stages.back());


### PR DESCRIPTION
This ensures that all of a substage's inputs are valid during its destructor. The current behavior relies on cppexpose's property management to destroy stages and pipeline inputs in arbitrary order.