### PR TITLE
Change color gradient texture format to GL_BGRA

### DIFF
--- a/source/gloperate/source/base/AbstractColorGradient.cpp
+++ b/source/gloperate/source/base/AbstractColorGradient.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<globjects::Texture> AbstractColorGradient::generateTexture(size_
 
     std::vector<unsigned char> data = pixelData(numPixels);
 
-    texture->image1D(0, gl::GL_RGBA, numPixels, 0, gl::GL_RGBA, gl::GL_UNSIGNED_BYTE, data.data());
+    texture->image1D(0, gl::GL_RGBA, numPixels, 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
 
     return texture;
 }


### PR DESCRIPTION
The pixel data is created using BGRA channel order (line 48), therefore the format parameter to `image1D` should be `GL_BGRA`, not `GL_RGBA` to correctly unpack the data.