### PR TITLE
OpenGL context as cmd line argument

### DIFF
--- a/source/applications/gloperate-viewer/main.cpp
+++ b/source/applications/gloperate-viewer/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        if(!format.initializeFromString(contextString));
+        if(!format.initializeFromString(contextString))
             return 1;
         QSurfaceFormat qFormat = gloperate_qt::GLContextFactory::toQSurfaceFormat(format);
         window->setFormat(qFormat);

--- a/source/applications/gloperate-viewer/main.cpp
+++ b/source/applications/gloperate-viewer/main.cpp
@@ -1,6 +1,8 @@
 
 #include <QQmlContext>
 
+#include <cppassist/cmdline/ArgumentParser.h>
+
 #include <cppexpose/scripting/ScriptContext.h>
 #include <cppexpose/reflection/Property.h>
 
@@ -9,6 +11,7 @@
 #include <gloperate/base/Environment.h>
 
 #include <gloperate-qt/base/GLContext.h>
+#include <gloperate-qt/base/GLContextFactory.h>
 #include <gloperate-qt/base/UpdateManager.h>
 
 #include <gloperate-qtquick/QuickView.h>
@@ -57,6 +60,16 @@ int main(int argc, char * argv[])
 
     // Load and show QML
     auto window = cppassist::make_unique<QuickView>(&qmlEngine);
+    // Specify desired context format
+    gloperate::GLContextFormat format;
+    cppassist::ArgumentParser argumentParser;
+    argumentParser.parse(argc, argv);
+    if(!argumentParser.params().empty())
+    {
+        format.initializeFromString(argumentParser.params().front());
+        QSurfaceFormat qFormat = gloperate_qt::GLContextFactory::toQSurfaceFormat(format);
+        window->setFormat(qFormat);
+    }
     window->setResizeMode(QQuickView::SizeRootObjectToView);
     window->setSource(QUrl::fromLocalFile(qmlEngine.gloperateModulePath() + "/Viewer.qml"));
     window->setGeometry(100, 100, 1280, 720);

--- a/source/applications/gloperate-viewer/main.cpp
+++ b/source/applications/gloperate-viewer/main.cpp
@@ -61,12 +61,13 @@ int main(int argc, char * argv[])
     // Load and show QML
     auto window = cppassist::make_unique<QuickView>(&qmlEngine);
     // Specify desired context format
-    gloperate::GLContextFormat format;
     cppassist::ArgumentParser argumentParser;
     argumentParser.parse(argc, argv);
-    if(!argumentParser.params().empty())
+    const auto contextString = argumentParser.value("--context");
+    if(!contextString.empty())
     {
-        format.initializeFromString(argumentParser.params().front());
+        gloperate::GLContextFormat format;
+        format.initializeFromString(contextString);
         QSurfaceFormat qFormat = gloperate_qt::GLContextFactory::toQSurfaceFormat(format);
         window->setFormat(qFormat);
     }

--- a/source/applications/gloperate-viewer/main.cpp
+++ b/source/applications/gloperate-viewer/main.cpp
@@ -67,7 +67,8 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        format.initializeFromString(contextString);
+        if(!format.initializeFromString(contextString));
+            return 1;
         QSurfaceFormat qFormat = gloperate_qt::GLContextFactory::toQSurfaceFormat(format);
         window->setFormat(qFormat);
     }

--- a/source/examples/gloperate-glfw-example/main.cpp
+++ b/source/examples/gloperate-glfw-example/main.cpp
@@ -1,5 +1,6 @@
 
 #include <cppassist/logging/logging.h>
+#include <cppassist/cmdline/ArgumentParser.h>
 
 #include <gloperate/gloperate.h>
 #include <gloperate/base/Environment.h>
@@ -36,6 +37,17 @@ int main(int argc, char * argv[])
 
     // Create render window
     RenderWindow window(&environment);
+    // Specify desired context format
+    cppassist::ArgumentParser argumentParser;
+    argumentParser.parse(argc, argv);
+    const auto contextString = argumentParser.value("--context");
+    if(!contextString.empty())
+    {
+        gloperate::GLContextFormat format;
+        format.initializeFromString(contextString);
+        window.setContextFormat(format);
+    }
+
     window.setRenderStage(std::move(renderStage));
     window.setTitle("gloperate viewer");
     window.setSize(1280, 720);

--- a/source/examples/gloperate-glfw-example/main.cpp
+++ b/source/examples/gloperate-glfw-example/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        if(!format.initializeFromString(contextString));
+        if(!format.initializeFromString(contextString))
             return 1;
         window.setContextFormat(format);
     }

--- a/source/examples/gloperate-glfw-example/main.cpp
+++ b/source/examples/gloperate-glfw-example/main.cpp
@@ -44,7 +44,8 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        format.initializeFromString(contextString);
+        if(!format.initializeFromString(contextString));
+            return 1;
         window.setContextFormat(format);
     }
 

--- a/source/examples/gloperate-qt-example/main.cpp
+++ b/source/examples/gloperate-qt-example/main.cpp
@@ -4,6 +4,7 @@
 #include <QDockWidget>
 
 #include <cppassist/logging/logging.h>
+#include <cppassist/cmdline/ArgumentParser.h>
 
 #include <gloperate/gloperate.h>
 #include <gloperate/base/Environment.h>
@@ -46,7 +47,12 @@ int main(int argc, char * argv[])
 
     // Specify desired context format
     gloperate::GLContextFormat format;
-    format.initializeFromString("OpenGL3.0None:ForwardCompatiblity=true:Debug:NoError=false");
+    cppassist::ArgumentParser argumentParser;
+    argumentParser.parse(argc, argv);
+    if(!argumentParser.params().empty())
+    {
+        format.initializeFromString(argumentParser.params().front());
+    }
 
     // Create render window
     auto window = cppassist::make_unique<RenderWindow>(&environment);

--- a/source/examples/gloperate-qt-example/main.cpp
+++ b/source/examples/gloperate-qt-example/main.cpp
@@ -54,7 +54,8 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        format.initializeFromString(contextString);
+        if(!format.initializeFromString(contextString));
+            return 1;
         window->setContextFormat(format);
     }
     auto windowRaw = window.get();

--- a/source/examples/gloperate-qt-example/main.cpp
+++ b/source/examples/gloperate-qt-example/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        if(!format.initializeFromString(contextString));
+        if(!format.initializeFromString(contextString))
             return 1;
         window->setContextFormat(format);
     }

--- a/source/examples/gloperate-qt-example/main.cpp
+++ b/source/examples/gloperate-qt-example/main.cpp
@@ -45,19 +45,19 @@ int main(int argc, char * argv[])
     // Create render stage
     auto renderStage = environment.componentManager()->component<Stage>("DemoStage")->createInstance(&environment);
 
-    // Specify desired context format
-    gloperate::GLContextFormat format;
-    cppassist::ArgumentParser argumentParser;
-    argumentParser.parse(argc, argv);
-    if(!argumentParser.params().empty())
-    {
-        format.initializeFromString(argumentParser.params().front());
-    }
-
     // Create render window
     auto window = cppassist::make_unique<RenderWindow>(&environment);
+    // Specify desired context format
+    cppassist::ArgumentParser argumentParser;
+    argumentParser.parse(argc, argv);
+    const auto contextString = argumentParser.value("--context");
+    if(!contextString.empty())
+    {
+        gloperate::GLContextFormat format;
+        format.initializeFromString(contextString);
+        window->setContextFormat(format);
+    }
     auto windowRaw = window.get();
-    window->setContextFormat(format);
     window->createContext();
     window->setRenderStage(std::move(renderStage));
 

--- a/source/examples/gloperate-qt-example/main.cpp
+++ b/source/examples/gloperate-qt-example/main.cpp
@@ -44,9 +44,14 @@ int main(int argc, char * argv[])
     // Create render stage
     auto renderStage = environment.componentManager()->component<Stage>("DemoStage")->createInstance(&environment);
 
+    // Specify desired context format
+    gloperate::GLContextFormat format;
+    format.initializeFromString("OpenGL3.0None:ForwardCompatiblity=true:Debug:NoError=false");
+
     // Create render window
     auto window = cppassist::make_unique<RenderWindow>(&environment);
     auto windowRaw = window.get();
+    window->setContextFormat(format);
     window->createContext();
     window->setRenderStage(std::move(renderStage));
 

--- a/source/examples/gloperate-qtquick-example/main.cpp
+++ b/source/examples/gloperate-qtquick-example/main.cpp
@@ -2,11 +2,14 @@
 #include <QApplication>
 #include <QQmlEngine>
 
+#include <cppassist/cmdline/ArgumentParser.h>
+
 #include <gloperate/gloperate.h>
 #include <gloperate/base/Environment.h>
 #include <gloperate/base/GLContextUtils.h>
 
 #include <gloperate-qt/base/GLContext.h>
+#include <gloperate-qt/base/GLContextFactory.h>
 #include <gloperate-qt/base/Application.h>
 #include <gloperate-qt/base/UpdateManager.h>
 
@@ -46,6 +49,17 @@ int main(int argc, char * argv[])
 
     // Load and show QML
     QuickView window(&qmlEngine);
+    // Specify desired context format
+    cppassist::ArgumentParser argumentParser;
+    argumentParser.parse(argc, argv);
+    const auto contextString = argumentParser.value("--context");
+    if(!contextString.empty())
+    {
+        gloperate::GLContextFormat format;
+        format.initializeFromString(contextString);
+        QSurfaceFormat qFormat = gloperate_qt::GLContextFactory::toQSurfaceFormat(format);
+        window.setFormat(qFormat);
+    }
     window.setResizeMode(QQuickView::SizeRootObjectToView);
     window.setSource(QUrl::fromLocalFile(qmlEngine.gloperateModulePath() + "/ExampleViewer.qml"));
     window.setGeometry(100, 100, 1280, 720);

--- a/source/examples/gloperate-qtquick-example/main.cpp
+++ b/source/examples/gloperate-qtquick-example/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        if(!format.initializeFromString(contextString));
+        if(!format.initializeFromString(contextString))
             return 1;
         QSurfaceFormat qFormat = gloperate_qt::GLContextFactory::toQSurfaceFormat(format);
         window.setFormat(qFormat);

--- a/source/examples/gloperate-qtquick-example/main.cpp
+++ b/source/examples/gloperate-qtquick-example/main.cpp
@@ -56,7 +56,8 @@ int main(int argc, char * argv[])
     if(!contextString.empty())
     {
         gloperate::GLContextFormat format;
-        format.initializeFromString(contextString);
+        if(!format.initializeFromString(contextString));
+            return 1;
         QSurfaceFormat qFormat = gloperate_qt::GLContextFactory::toQSurfaceFormat(format);
         window.setFormat(qFormat);
     }

--- a/source/gloperate/include/gloperate/base/GLContextFormat.h
+++ b/source/gloperate/include/gloperate/base/GLContextFormat.h
@@ -439,7 +439,7 @@ public:
      *    Bool parameter without the '=<flagvalue>' are considered as 'true'
      *    i.e. OpenGL3.2Core:Debug <=> OpenGL3.2Core:Debug=true
      */
-    void initializeFromString(const std::string & formatString);
+    bool initializeFromString(const std::string & formatString);
 
 
 protected:

--- a/source/gloperate/include/gloperate/base/GLContextFormat.h
+++ b/source/gloperate/include/gloperate/base/GLContextFormat.h
@@ -399,6 +399,27 @@ public:
     */
     bool verify(const GLContextFormat & requested) const;
 
+    /**
+     * @brief
+     *   Create a string representing the Format using the scheme
+     *   "OpenGL<majorVersion>.<minorVersion><profile>[:<flagname>=<flagvalue>]*".
+     *   e.g. OpenGL4.5Core:SwapBehavior=SingleBuffering
+     *
+     * @return
+     *   The format as string.
+     */
+    std::string toString() const;
+
+    /**
+     * @brief
+     *   Update format attributes from string representation
+     *
+     * @param[in] formatString
+     *   "OpenGL<majorVersion>.<minorVersion><profile>[:<flagname>=<flagvalue>]*"
+     *   e.g. OpenGL4.5Core:SwapBehavior=SingleBuffering
+     */
+    void initializeFromString(std::string formatString);
+
 
 protected:
     /**

--- a/source/gloperate/include/gloperate/base/GLContextFormat.h
+++ b/source/gloperate/include/gloperate/base/GLContextFormat.h
@@ -222,6 +222,24 @@ public:
 
     /**
     *  @brief
+    *    Get noerror context mode
+    *
+    *  @return
+    *    noerror context mode (default: false)
+    */
+    bool noErrorContext() const;
+
+    /**
+    *  @brief
+    *    Set noerror context mode
+    *
+    *  @param[in] on
+    *    noerror context mode
+    */
+    void setNoErrorContext(bool on);
+
+    /**
+    *  @brief
     *    Get buffer size for red color channel
     *
     *  @return
@@ -400,25 +418,28 @@ public:
     bool verify(const GLContextFormat & requested) const;
 
     /**
-     * @brief
-     *   Create a string representing the Format using the scheme
-     *   "OpenGL<majorVersion>.<minorVersion><profile>[:<flagname>=<flagvalue>]*".
-     *   e.g. OpenGL4.5Core:SwapBehavior=SingleBuffering
+     *  @brief
+     *    Create a string representing the Format using the scheme
+     *    "OpenGL<majorVersion>.<minorVersion><profile>[:<flagname>=<flagvalue>]*".
      *
-     * @return
-     *   The format as string.
+     *  @return
+     *    The format as string.
      */
     std::string toString() const;
 
     /**
-     * @brief
-     *   Update format attributes from string representation
+     *  @brief
+     *    Update format attributes from string representation
      *
-     * @param[in] formatString
-     *   "OpenGL<majorVersion>.<minorVersion><profile>[:<flagname>=<flagvalue>]*"
-     *   e.g. OpenGL4.5Core:SwapBehavior=SingleBuffering
+     *  @param[in] formatString
+     *    "OpenGL<majorVersion>.<minorVersion><profile>[:<flagname>=<flagvalue>]*"
+     *    e.g. OpenGL3.0None:ForwardCompatiblity=true:Debug=true:NoError=true
+     *
+     *  @remarks
+     *    Bool parameter without the '=<flagvalue>' are considered as 'true'
+     *    i.e. OpenGL3.2Core:Debug <=> OpenGL3.2Core:Debug=true
      */
-    void initializeFromString(std::string formatString);
+    void initializeFromString(const std::string & formatString);
 
 
 protected:
@@ -482,6 +503,7 @@ protected:
 
     bool m_forwardCompatibility;        ///< Forward compatibility mode
     bool m_debugContext;                ///< Debug context mode
+    bool m_noerror;                     ///< NoError context mode
 
     unsigned int m_redBufferSize;       ///< Buffer size for red color channel
     unsigned int m_greenBufferSize;     ///< Buffer size for green color channel

--- a/source/gloperate/include/gloperate/base/GLContextFormat.h
+++ b/source/gloperate/include/gloperate/base/GLContextFormat.h
@@ -222,19 +222,19 @@ public:
 
     /**
     *  @brief
-    *    Get noerror context mode
+    *    Get KHR_no_error context mode
     *
     *  @return
-    *    noerror context mode (default: false)
+    *    KHR_no_error context mode (default: false)
     */
     bool noErrorContext() const;
 
     /**
     *  @brief
-    *    Set noerror context mode
+    *    Set KHR_no_error context mode
     *
     *  @param[in] on
-    *    noerror context mode
+    *    KHR_no_error context mode
     */
     void setNoErrorContext(bool on);
 
@@ -503,7 +503,7 @@ protected:
 
     bool m_forwardCompatibility;        ///< Forward compatibility mode
     bool m_debugContext;                ///< Debug context mode
-    bool m_noerror;                     ///< NoError context mode
+    bool m_noerror;                     ///< KHR_no_error context mode
 
     unsigned int m_redBufferSize;       ///< Buffer size for red color channel
     unsigned int m_greenBufferSize;     ///< Buffer size for green color channel

--- a/source/gloperate/source/base/GLContextFormat.cpp
+++ b/source/gloperate/source/base/GLContextFormat.cpp
@@ -7,6 +7,7 @@
 // TODO use cppassist regex
 #include <regex>
 
+#include <cppassist/string/conversion.h>
 #include <cppassist/logging/logging.h>
 
 
@@ -281,7 +282,7 @@ std::string GLContextFormat::toString() const
     return result;
 }
 
-void GLContextFormat::initializeFromString(const std::string &formatString)
+bool GLContextFormat::initializeFromString(const std::string &formatString)
 {
     /* captures
      * 1 major version
@@ -296,12 +297,12 @@ void GLContextFormat::initializeFromString(const std::string &formatString)
     if(match.empty())
     {
         cppassist::error("gloperate") << "requested contex string is ill-formed. Exiting";
-        exit(1);
+        return false;
     }
 
     // set version
-    const auto version_major = std::stoi(match[1]);
-    const auto version_minor = std::stoi(match[2]);
+    const auto version_major = cppassist::string::fromString<int>(match[1]);
+    const auto version_minor = cppassist::string::fromString<int>(match[2]);
     setVersion(version_major, version_minor);
 
     // set profile
@@ -348,6 +349,7 @@ void GLContextFormat::initializeFromString(const std::string &formatString)
 
         remainingParams = static_cast<std::string>(match[4]);
     }
+    return true;
 }
 
 bool GLContextFormat::verifyVersionAndProfile(const GLContextFormat & requested) const


### PR DESCRIPTION
Scheme for Context String is `OpenGL<majorVersion>.<minorVersion><profile>[:<flagname>=<flagvalue>]*`
e.g. OpenGL3.0None:ForwardCompatiblity=true:Debug=true:NoError=true

Bool parameter without the '=<flagvalue>' are considered as 'true'
i.e. OpenGL3.2Core:Debug <=> OpenGL3.2Core:Debug=true

![image](https://cloud.githubusercontent.com/assets/12047669/24910772/1c25a570-1ec9-11e7-9b3a-e9f32bad514a.png)

