### PR TITLE
Handle pipeline switch crash

### DIFF
--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -246,7 +246,6 @@ ApplicationWindow
         {
             settings.stage = name;
             window.stage   = name;
-            propertyEditor.update();
         }
     }
 
@@ -276,9 +275,10 @@ ApplicationWindow
 
                 stage: window.stage
 
-                onCanvasInitialized:
+                onRenderStageReplaced:
                 {
                     gloperatePipeline.root = gloperate.canvas0.pipeline;
+                    propertyEditor.update();
                 }
             }
 
@@ -306,11 +306,6 @@ ApplicationWindow
 
                         pipelineInterface: gloperatePipeline
                         path:              'pipeline.' + window.stage
-
-                        Component.onCompleted:
-                        {
-                            propertyEditor.update()
-                        }
                     }
                 }
             }
@@ -422,7 +417,6 @@ ApplicationWindow
 
         // Set render stage
         window.stage = settings.stage;
-        propertyEditor.update();
 
         // Show window
         window.visible = true;

--- a/source/examples/demo-stages-plugins/DemoStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoStage.cpp
@@ -90,6 +90,12 @@ void DemoStage::onContextInit(gloperate::AbstractGLContext *)
 
 void DemoStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
+    m_vao.reset(nullptr);
+    m_buffer.reset(nullptr);
+    m_texture.reset(nullptr);
+    m_program.reset(nullptr);
+    m_vertexShader.reset(nullptr);
+    m_fragmentShader.reset(nullptr);
 }
 
 void DemoStage::onProcess(gloperate::AbstractGLContext *)

--- a/source/gloperate-qtquick/include/gloperate-qtquick/RenderItem.h
+++ b/source/gloperate-qtquick/include/gloperate-qtquick/RenderItem.h
@@ -114,19 +114,6 @@ protected:
 
 
 protected:
-    class RenderStageInitialization : public QRunnable
-    {
-    public:
-        RenderStageInitialization(gloperate::Stage * stage, gloperate::Canvas * canvas);
-
-        virtual void run() override;
-
-
-    protected:
-        gloperate::Canvas * m_canvas; ///< The canvas
-        gloperate::Stage *  m_stage;  ///< The new stage
-    };
-
     class RenderStageCleanup : public QRunnable
     {
     public:

--- a/source/gloperate-qtquick/include/gloperate-qtquick/TextureItem.h
+++ b/source/gloperate-qtquick/include/gloperate-qtquick/TextureItem.h
@@ -10,8 +10,6 @@
 #include <gloperate-qtquick/gloperate-qtquick_api.h>
 
 
-class QQuickWindow;
-
 namespace globjects
 {
     class Framebuffer;

--- a/source/gloperate-qtquick/source/RenderItem.cpp
+++ b/source/gloperate-qtquick/source/RenderItem.cpp
@@ -55,7 +55,7 @@ void RenderItem::setStage(const QString & name)
 {
     if (m_canvas)
     {
-        // Create and updaterender stage
+        // Create and update render stage
         // Stage is saved internally
         updateStage(name);
     }
@@ -126,6 +126,9 @@ void RenderItem::createCanvasWithStage(const QString & stage)
 
     // Inform about initialization of the canvas
     emit canvasInitialized();
+
+    // Inform about replacement of the render stage
+    emit renderStageReplaced();
 }
 
 void RenderItem::updateStage(const QString & stage)
@@ -144,9 +147,16 @@ void RenderItem::updateStage(const QString & stage)
 
     // Update render stage
     m_stage = stage;
-    static_cast<gloperate::Canvas*>(m_canvas.get())->setRenderStage(
-        std::move(stageInstance)
-    );
+
+    auto canvas = static_cast<gloperate::Canvas*>(m_canvas.get());
+
+    window()->scheduleRenderJob(new RenderStageCleanup(canvas->obtainRenderStage(), canvas), QQuickWindow::BeforeRenderingStage);
+    window()->scheduleRenderJob(new RenderStageInitialization(stageInstance.get(), canvas), QQuickWindow::BeforeRenderingStage);
+
+    canvas->setRenderStage(std::move(stageInstance));
+
+    // Inform about replacement of the render stage
+    emit renderStageReplaced();
 }
 
 void RenderItem::keyPressEvent(QKeyEvent * event)
@@ -229,6 +239,38 @@ void RenderItem::wheelEvent(QWheelEvent * event)
                         (int)(event->y() * window()->devicePixelRatio()) )
         );
     }
+}
+
+void RenderItem::releaseResources()
+{
+    if (m_canvas)
+    {
+        m_canvas->onContextDeinit();
+    }
+}
+
+
+RenderItem::RenderStageInitialization::RenderStageInitialization(gloperate::Stage * stage, gloperate::Canvas * canvas)
+: m_canvas(canvas)
+, m_stage(stage)
+{
+}
+
+void RenderItem::RenderStageInitialization::run()
+{
+    m_stage->initContext(m_canvas->openGLContext());
+}
+
+
+RenderItem::RenderStageCleanup::RenderStageCleanup(std::unique_ptr<gloperate::Stage> && stage, gloperate::Canvas * canvas)
+: m_canvas(canvas)
+, m_stage(std::move(stage))
+{
+}
+
+void RenderItem::RenderStageCleanup::run()
+{
+    m_stage->deinitContext(m_canvas->openGLContext());
 }
 
 

--- a/source/gloperate-qtquick/source/RenderItem.cpp
+++ b/source/gloperate-qtquick/source/RenderItem.cpp
@@ -153,7 +153,7 @@ void RenderItem::updateStage(const QString & stage)
     window()->scheduleRenderJob(new RenderStageCleanup(canvas->obtainRenderStage(), canvas), QQuickWindow::BeforeRenderingStage);
     window()->scheduleRenderJob(new RenderStageInitialization(stageInstance.get(), canvas), QQuickWindow::BeforeRenderingStage);
 
-    canvas->setRenderStage(std::move(stageInstance));
+    canvas->setUninitializedRenderStage(std::move(stageInstance));
 
     // Inform about replacement of the render stage
     emit renderStageReplaced();
@@ -259,6 +259,8 @@ RenderItem::RenderStageInitialization::RenderStageInitialization(gloperate::Stag
 void RenderItem::RenderStageInitialization::run()
 {
     m_stage->initContext(m_canvas->openGLContext());
+    m_canvas->setRenderStageInitialized(true);
+    m_canvas->redraw();
 }
 
 
@@ -270,7 +272,10 @@ RenderItem::RenderStageCleanup::RenderStageCleanup(std::unique_ptr<gloperate::St
 
 void RenderItem::RenderStageCleanup::run()
 {
-    m_stage->deinitContext(m_canvas->openGLContext());
+    if (m_stage)
+    {
+        m_stage->deinitContext(m_canvas->openGLContext());
+    }
 }
 
 

--- a/source/gloperate-qtquick/source/TextureItem.cpp
+++ b/source/gloperate-qtquick/source/TextureItem.cpp
@@ -2,7 +2,6 @@
 #include <gloperate-qtquick/TextureItem.h>
 
 #include <QQmlContext>
-#include <QQuickWindow>
 
 #include <glm/vec2.hpp>
 #include <glm/vec4.hpp>

--- a/source/gloperate-qtquick/source/TextureItemRenderer.cpp
+++ b/source/gloperate-qtquick/source/TextureItemRenderer.cpp
@@ -1,9 +1,9 @@
 
 #include <gloperate-qtquick/TextureItemRenderer.h>
 
-#include <QQuickWindow>
 #include <QOpenGLFramebufferObject>
 #include <QOpenGLContext>
+#include <QQuickWindow>
 
 #include <cppassist/memory/make_unique.h>
 

--- a/source/gloperate/include/gloperate/base/Canvas.h
+++ b/source/gloperate/include/gloperate/base/Canvas.h
@@ -91,7 +91,7 @@ public:
 
     /**
     *  @brief
-    *    Set render stage
+    *    Set render stage and initializes it immediately
     *
     *  @param[in] stage
     *    Render stage that renders into the current context (can be null)
@@ -101,6 +101,32 @@ public:
     *    The canvas takes ownership over the stage.
     */
     void setRenderStage(std::unique_ptr<Stage> && stage);
+
+    /**
+    *  @brief
+    *    Set render stage, assume it will be initialized later
+    *
+    *  @param[in] stage
+    *    Render stage that renders into the current context (can be null)
+    *
+    *  @remarks
+    *    When setting a new render stage, the old render stage is destroyed.
+    *    The canvas takes ownership over the stage.
+    */
+    void setUninitializedRenderStage(std::unique_ptr<Stage> && stage);
+
+    /**
+    *  @brief
+    *    Update render stage initialization status.
+    *
+    *  @param[in] initialized
+    *    The initialization status
+    *
+    *  @remarks
+    *    A rendering is triggered only if the rneder stage is
+    *    marked as initialized.
+    */
+    void setRenderStageInitialized(bool initialized);
 
     // Virtual AbstractCanvas functions
     virtual void onRender(globjects::Framebuffer * targetFBO) override;
@@ -121,14 +147,15 @@ public:
 
 
 protected:
-    PipelineContainer               m_pipelineContainer; ///< Container for the rendering stage or pipeline
-    unsigned long                   m_frame;             ///< Frame counter
-    std::unique_ptr<MouseDevice>    m_mouseDevice;       ///< Device for Mouse Events
-    std::unique_ptr<KeyboardDevice> m_keyboardDevice;    ///< Device for Keyboard Events
-    glm::vec4                       m_deviceViewport;    ///< Last known device viewport configuration
-    glm::vec4                       m_virtualViewport;   ///< Last known virtual viewport configuration
-    glm::vec4                       m_savedDeviceVP;     ///< Saved device viewport configuration
-    glm::vec4                       m_savedVirtualVP;    ///< Saved virtual viewport configuration
+    PipelineContainer               m_pipelineContainer;      ///< Container for the rendering stage or pipeline
+    bool                            m_renderStageInitialized; ///< Initialization status of render stage
+    unsigned long                   m_frame;                  ///< Frame counter
+    std::unique_ptr<MouseDevice>    m_mouseDevice;            ///< Device for Mouse Events
+    std::unique_ptr<KeyboardDevice> m_keyboardDevice;         ///< Device for Keyboard Events
+    glm::vec4                       m_deviceViewport;         ///< Last known device viewport configuration
+    glm::vec4                       m_virtualViewport;        ///< Last known virtual viewport configuration
+    glm::vec4                       m_savedDeviceVP;          ///< Saved device viewport configuration
+    glm::vec4                       m_savedVirtualVP;         ///< Saved virtual viewport configuration
 };
 
 

--- a/source/gloperate/include/gloperate/base/Canvas.h
+++ b/source/gloperate/include/gloperate/base/Canvas.h
@@ -76,6 +76,21 @@ public:
 
     /**
     *  @brief
+    *    Release and return current render stage
+    *
+    *  @return
+    *    The current render stage
+    *
+    *  @remarks
+    *    The pipeline container is always empty after this function call.
+    *    If the return value is not used, the stage gets deleted immediately
+    *    (potentionally leaking OpenGL resources or crash upon deletion
+    *    because of a missing current OpenGL context).
+    */
+    std::unique_ptr<Stage> obtainRenderStage();
+
+    /**
+    *  @brief
     *    Set render stage
     *
     *  @param[in] stage

--- a/source/gloperate/include/gloperate/pipeline/PipelineContainer.h
+++ b/source/gloperate/include/gloperate/pipeline/PipelineContainer.h
@@ -80,6 +80,21 @@ public:
     */
     void setRenderStage(std::unique_ptr<Stage> && stage);
 
+    /**
+    *  @brief
+    *    Release and return current render stage
+    *
+    *  @return
+    *    The current render stage
+    *
+    *  @remarks
+    *    The pipeline container is always empty after this function call.
+    *    If the return value is not used, the stage gets deleted immediately
+    *    (potentionally leaking OpenGL resources or crash upon deletion
+    *    because of a missing current OpenGL context).
+    */
+    std::unique_ptr<Stage> obtainRenderStage();
+
 
 protected:
     void connect(Stage * stage, const std::string & name, AbstractSlot * source);

--- a/source/gloperate/source/base/AbstractGLContext.cpp
+++ b/source/gloperate/source/base/AbstractGLContext.cpp
@@ -33,7 +33,7 @@ void AbstractGLContext::initializeGLBinding()
 {
     glbinding::Binding::initialize(false);
     globjects::init();
-#ifdef DEBUG
+#ifndef NDEBUG
     globjects::DebugMessage::enable(true);
 #endif
 }

--- a/source/gloperate/source/base/Canvas.cpp
+++ b/source/gloperate/source/base/Canvas.cpp
@@ -71,19 +71,19 @@ Stage * Canvas::renderStage()
 void Canvas::setRenderStage(std::unique_ptr<Stage> && stage)
 {
     // De-initialize render stage
-    if (m_pipelineContainer.renderStage() && m_openGLContext)
+    /*if (m_pipelineContainer.renderStage() && m_openGLContext)
     {
         m_pipelineContainer.renderStage()->deinitContext(m_openGLContext);
-    }
+    }*/
 
     // Set new render stage
     m_pipelineContainer.setRenderStage(std::move(stage));
 
     // Initialize new render stage
-    if (m_pipelineContainer.renderStage() && m_openGLContext)
+    /*if (m_pipelineContainer.renderStage() && m_openGLContext)
     {
         m_pipelineContainer.renderStage()->initContext(m_openGLContext);
-    }
+    }*/
 }
 
 void Canvas::onRender(globjects::Framebuffer * targetFBO)
@@ -207,6 +207,11 @@ void Canvas::onMouseWheel(const glm::vec2 & delta, const glm::ivec2 & pos)
 const glm::vec4 & Canvas::savedDeviceViewport() const
 {
     return m_savedDeviceVP;
+}
+
+std::unique_ptr<Stage> Canvas::obtainRenderStage()
+{
+    return m_pipelineContainer.obtainRenderStage();
 }
 
 

--- a/source/gloperate/source/base/Canvas.cpp
+++ b/source/gloperate/source/base/Canvas.cpp
@@ -77,7 +77,7 @@ void Canvas::setRenderStage(std::unique_ptr<Stage> && stage)
     if (m_pipelineContainer.renderStage() && m_openGLContext)
     {
         m_pipelineContainer.renderStage()->initContext(m_openGLContext);
-        m_renderStageInitialized = false;
+        m_renderStageInitialized = true;
     }
 }
 
@@ -104,8 +104,14 @@ void Canvas::onRender(globjects::Framebuffer * targetFBO)
     }
 
     // Invoke render stage/pipeline
-    if (m_pipelineContainer.renderStage() && m_renderStageInitialized)
+    if (m_pipelineContainer.renderStage())
     {
+        if (!m_renderStageInitialized)
+        {
+            m_pipelineContainer.renderStage()->initContext(m_openGLContext);
+            m_renderStageInitialized = true;
+        }
+
         m_frame++;
 
         m_pipelineContainer.frameCounter.setValue(m_frame);
@@ -127,11 +133,13 @@ void Canvas::onContextInit()
     cppassist::debug(2, "gloperate") << "onContextInit()";
 
     // Initialize render stage in new context
-    if (m_pipelineContainer.renderStage())
+
+    // This is maybe called from the wrong thread; need to validate on GCC
+    /*if (m_pipelineContainer.renderStage())
     {
         m_pipelineContainer.renderStage()->initContext(m_openGLContext);
         m_renderStageInitialized = true;
-    }
+    }*/
 }
 
 void Canvas::onContextDeinit()

--- a/source/gloperate/source/pipeline/PipelineContainer.cpp
+++ b/source/gloperate/source/pipeline/PipelineContainer.cpp
@@ -115,5 +115,10 @@ void PipelineContainer::disconnect(Stage * stage, const std::string & name)
     input->disconnect();
 }
 
+std::unique_ptr<Stage> PipelineContainer::obtainRenderStage()
+{
+    return std::move(m_renderStage);
+}
+
 
 } // namespace gloperate


### PR DESCRIPTION
Split render stage initialization and deinitialization across the main thread and the render thread.

**Context**

Steps that needs to get executed in main thread:
* `RenderItem::setStage` as it's called from QML
* Update `PipelineContainer::m_renderStage` instance to be available in QML
* Emit `RenderItem::renderStageReplaced` as QML listens on that signal and QML seems to assume to get executed in main thread
* `Stage` constructor as some stages may initialize timers that are required to get started in main thread

Steps that needs to get executed in render thread:
* `Stage::onContextDeinit`
* `Stage::onContextInit`

**Approach**

1. Use `QQuickWindow::scheduleRenderJob` to move stage initialization and deinitialization to render thread.
2. Register stage instance in main thread either way, so that QML can update in *correct* thread.
3. Track initialization of render stage explicitly to omit rendering of uninitialized stages that *may* occur through concurrent execution of main and render thread.

**Discussion**

1. Do we need mutexes here?
2. Currently, the new stage seems to be available one frame late. I think it's more like the former stage is shown one frame too much. Maybe we should add a framebuffer clear if no stage can be rendered (e.g., because it's uninitialized)

**Tests**

This PR is currently tested on Ubuntu 16.04 with Qt 5.5.1 and the full middleware compiled using clang 4.0.