### PR TITLE
Remove context parameter from onProcess()

### DIFF
--- a/source/examples/demo-stages-plugins/ColorizeStage.cpp
+++ b/source/examples/demo-stages-plugins/ColorizeStage.cpp
@@ -44,7 +44,7 @@ void ColorizeStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
 }
 
-void ColorizeStage::onProcess(gloperate::AbstractGLContext *)
+void ColorizeStage::onProcess()
 {
     // Activate FBO
     globjects::Framebuffer * fbo = *renderInterface.targetFBO;

--- a/source/examples/demo-stages-plugins/ColorizeStage.h
+++ b/source/examples/demo-stages-plugins/ColorizeStage.h
@@ -73,7 +73,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/examples/demo-stages-plugins/DemoAntialiasableTriangleStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoAntialiasableTriangleStage.cpp
@@ -74,7 +74,7 @@ void DemoAntialiasableTriangleStage::onContextDeinit(gloperate::AbstractGLContex
 {
 }
 
-void DemoAntialiasableTriangleStage::onProcess(gloperate::AbstractGLContext *)
+void DemoAntialiasableTriangleStage::onProcess()
 {
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;

--- a/source/examples/demo-stages-plugins/DemoAntialiasableTriangleStage.h
+++ b/source/examples/demo-stages-plugins/DemoAntialiasableTriangleStage.h
@@ -65,7 +65,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
     virtual void onInputValueChanged(gloperate::AbstractSlot * slot) override;
 
     // Helper functions

--- a/source/examples/demo-stages-plugins/DemoAntialiasingPipeline.h
+++ b/source/examples/demo-stages-plugins/DemoAntialiasingPipeline.h
@@ -9,17 +9,14 @@
 #include <gloperate/stages/interfaces/RenderInterface.h>
 
 
-namespace gloperate_glkernel {
-
-class DiscDistributionKernelStage;
-
+namespace gloperate_glkernel
+{
+    class DiscDistributionKernelStage;
 }
 
 namespace gloperate
 {
-
-class SubpixelAntialiasingOffsetStage;
-
+    class SubpixelAntialiasingOffsetStage;
 }
 
 

--- a/source/examples/demo-stages-plugins/DemoDOFCubeStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoDOFCubeStage.cpp
@@ -108,7 +108,7 @@ void DemoDOFCubeStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
 }
 
-void DemoDOFCubeStage::onProcess(gloperate::AbstractGLContext *)
+void DemoDOFCubeStage::onProcess()
 {
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;

--- a/source/examples/demo-stages-plugins/DemoDOFCubeStage.h
+++ b/source/examples/demo-stages-plugins/DemoDOFCubeStage.h
@@ -65,7 +65,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/examples/demo-stages-plugins/DemoDOFPipeline.h
+++ b/source/examples/demo-stages-plugins/DemoDOFPipeline.h
@@ -9,17 +9,14 @@
 #include <gloperate/stages/interfaces/RenderInterface.h>
 
 
-namespace gloperate_glkernel {
-
-class DiscDistributionKernelStage;
-
+namespace gloperate_glkernel
+{
+    class DiscDistributionKernelStage;
 }
 
 namespace gloperate
 {
-
-class MultiFrameDiscDistributionStage;
-
+    class MultiFrameDiscDistributionStage;
 }
 
 class DemoDOFCubeStage;

--- a/source/examples/demo-stages-plugins/DemoDrawableStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoDrawableStage.cpp
@@ -56,7 +56,7 @@ void DemoDrawableStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
 }
 
-void DemoDrawableStage::onProcess(gloperate::AbstractGLContext *)
+void DemoDrawableStage::onProcess()
 {
     drawable.setValue(m_drawable.get());
 }

--- a/source/examples/demo-stages-plugins/DemoDrawableStage.h
+++ b/source/examples/demo-stages-plugins/DemoDrawableStage.h
@@ -74,7 +74,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/examples/demo-stages-plugins/DemoRenderStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoRenderStage.cpp
@@ -55,7 +55,7 @@ void DemoRenderStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
 }
 
-void DemoRenderStage::onProcess(gloperate::AbstractGLContext *)
+void DemoRenderStage::onProcess()
 {
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;

--- a/source/examples/demo-stages-plugins/DemoRenderStage.h
+++ b/source/examples/demo-stages-plugins/DemoRenderStage.h
@@ -75,7 +75,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/examples/demo-stages-plugins/DemoSSAOPostprocessingStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoSSAOPostprocessingStage.cpp
@@ -133,7 +133,7 @@ void DemoSSAOPostprocessingStage::onContextDeinit(gloperate::AbstractGLContext *
 {
 }
 
-void DemoSSAOPostprocessingStage::onProcess(gloperate::AbstractGLContext *)
+void DemoSSAOPostprocessingStage::onProcess()
 {
     if (!(*colorTexture && *normalTexture && *depthTexture && *ssaoKernel && *ssaoNoise))
     {

--- a/source/examples/demo-stages-plugins/DemoSSAOPostprocessingStage.h
+++ b/source/examples/demo-stages-plugins/DemoSSAOPostprocessingStage.h
@@ -75,7 +75,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/examples/demo-stages-plugins/DemoSSAORenderingStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoSSAORenderingStage.cpp
@@ -102,7 +102,7 @@ void DemoSSAORenderingStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
 }
 
-void DemoSSAORenderingStage::onProcess(gloperate::AbstractGLContext *)
+void DemoSSAORenderingStage::onProcess()
 {
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;

--- a/source/examples/demo-stages-plugins/DemoSSAORenderingStage.h
+++ b/source/examples/demo-stages-plugins/DemoSSAORenderingStage.h
@@ -65,7 +65,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/examples/demo-stages-plugins/DemoStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoStage.cpp
@@ -85,7 +85,7 @@ void DemoStage::onContextDeinit(gloperate::AbstractGLContext *)
     m_fragmentShader = nullptr;
 }
 
-void DemoStage::onProcess(gloperate::AbstractGLContext *)
+void DemoStage::onProcess()
 {
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;

--- a/source/examples/demo-stages-plugins/DemoStage.h
+++ b/source/examples/demo-stages-plugins/DemoStage.h
@@ -65,7 +65,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void createAndSetupCamera();

--- a/source/examples/demo-stages-plugins/DemoStage2.cpp
+++ b/source/examples/demo-stages-plugins/DemoStage2.cpp
@@ -75,7 +75,7 @@ void DemoStage2::onContextDeinit(gloperate::AbstractGLContext *)
     m_fragmentShaderSource = nullptr;
 }
 
-void DemoStage2::onProcess(gloperate::AbstractGLContext *)
+void DemoStage2::onProcess()
 {
     // Animate camera by 90° per second
     m_angle += 0.2f * glm::pi<float>() * (*renderInterface.timeDelta);

--- a/source/examples/demo-stages-plugins/DemoStage2.h
+++ b/source/examples/demo-stages-plugins/DemoStage2.h
@@ -74,7 +74,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/examples/demo-stages-plugins/DemoTransparencyPipeline.h
+++ b/source/examples/demo-stages-plugins/DemoTransparencyPipeline.h
@@ -10,16 +10,8 @@
 
 
 namespace gloperate_glkernel {
-
-class TransparencyKernelStage;
-class NoiseKernelStage;
-
-}
-
-namespace gloperate
-{
-
-
+    class TransparencyKernelStage;
+    class NoiseKernelStage;
 }
 
 

--- a/source/examples/demo-stages-plugins/DemoTransparencyStage.cpp
+++ b/source/examples/demo-stages-plugins/DemoTransparencyStage.cpp
@@ -115,7 +115,7 @@ void DemoTransparencyStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
 }
 
-void DemoTransparencyStage::onProcess(gloperate::AbstractGLContext *)
+void DemoTransparencyStage::onProcess()
 {
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;

--- a/source/examples/demo-stages-plugins/DemoTransparencyStage.h
+++ b/source/examples/demo-stages-plugins/DemoTransparencyStage.h
@@ -66,7 +66,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/examples/demo-stages-plugins/GlyphSequenceDemoStage.cpp
+++ b/source/examples/demo-stages-plugins/GlyphSequenceDemoStage.cpp
@@ -25,7 +25,7 @@ GlyphSequenceDemoStage::GlyphSequenceDemoStage(gloperate::Environment * environm
 {
 }
 
-void GlyphSequenceDemoStage::onProcess(gloperate::AbstractGLContext * /*context*/)
+void GlyphSequenceDemoStage::onProcess()
 {
     m_sequences.resize(1);
 

--- a/source/examples/demo-stages-plugins/GlyphSequenceDemoStage.h
+++ b/source/examples/demo-stages-plugins/GlyphSequenceDemoStage.h
@@ -47,7 +47,7 @@ public:
 
 
 protected:
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/examples/demo-stages-plugins/LightTestStage.cpp
+++ b/source/examples/demo-stages-plugins/LightTestStage.cpp
@@ -170,11 +170,8 @@ void LightTestStage::onContextInitialize(gloperate::AbstractGLContext *)
     globjects::NamedString::create("/gloperate/shaders/lightProcessingPhong.glsl", new globjects::File(dataFolderPath + "/gloperate/shaders/lightProcessingPhong.glsl"));
 }
 
-void LightTestStage::onProcess(gloperate::AbstractGLContext * context)
+void LightTestStage::onProcess()
 {
-    if (!m_program)
-        onContextInitialize(context);
-
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;
 

--- a/source/examples/demo-stages-plugins/LightTestStage.h
+++ b/source/examples/demo-stages-plugins/LightTestStage.h
@@ -71,7 +71,7 @@ public:
 protected:
     // Virtual Stage interface
     virtual void onContextInitialize(gloperate::AbstractGLContext * context);
-    virtual void onProcess(gloperate::AbstractGLContext * context);
+    virtual void onProcess();
 
 
 protected:

--- a/source/examples/demo-stages-plugins/SpinningRectStage.cpp
+++ b/source/examples/demo-stages-plugins/SpinningRectStage.cpp
@@ -94,7 +94,7 @@ void SpinningRectStage::onContextDeinit(gloperate::AbstractGLContext *)
     m_vao = nullptr;
 }
 
-void SpinningRectStage::onProcess(gloperate::AbstractGLContext *)
+void SpinningRectStage::onProcess()
 {
     // Get viewport
     glm::vec4 viewport = *renderInterface.deviceViewport;

--- a/source/examples/demo-stages-plugins/SpinningRectStage.h
+++ b/source/examples/demo-stages-plugins/SpinningRectStage.h
@@ -74,7 +74,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/examples/demo-stages-plugins/TimerStage.cpp
+++ b/source/examples/demo-stages-plugins/TimerStage.cpp
@@ -31,7 +31,7 @@ void TimerStage::onContextDeinit(gloperate::AbstractGLContext *)
 {
 }
 
-void TimerStage::onProcess(gloperate::AbstractGLContext *)
+void TimerStage::onProcess()
 {
     m_time += (*timeDelta) * (*factor);
 

--- a/source/examples/demo-stages-plugins/TimerStage.h
+++ b/source/examples/demo-stages-plugins/TimerStage.h
@@ -63,7 +63,7 @@ protected:
     // Virtual Stage functions
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/gloperate-glkernel/include/gloperate-glkernel/stages/DiscDistributionKernelStage.h
+++ b/source/gloperate-glkernel/include/gloperate-glkernel/stages/DiscDistributionKernelStage.h
@@ -71,7 +71,7 @@ public:
 protected:
     // Virtual Stage interface
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void resizeKernel();

--- a/source/gloperate-glkernel/include/gloperate-glkernel/stages/HemisphereDistributionKernelStage.h
+++ b/source/gloperate-glkernel/include/gloperate-glkernel/stages/HemisphereDistributionKernelStage.h
@@ -71,7 +71,7 @@ public:
 protected:
     // Virtual Stage interface
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void resizeKernel();

--- a/source/gloperate-glkernel/include/gloperate-glkernel/stages/MultiFrameAggregationPipeline.h
+++ b/source/gloperate-glkernel/include/gloperate-glkernel/stages/MultiFrameAggregationPipeline.h
@@ -86,7 +86,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void connectBasicRenderInterface(gloperate::RenderInterface & interface);

--- a/source/gloperate-glkernel/include/gloperate-glkernel/stages/MultiFrameAggregationStage.h
+++ b/source/gloperate-glkernel/include/gloperate-glkernel/stages/MultiFrameAggregationStage.h
@@ -76,7 +76,7 @@ public:
 protected:
     // Virtual Stage interface
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupGeometry();

--- a/source/gloperate-glkernel/include/gloperate-glkernel/stages/MultiFrameControlStage.h
+++ b/source/gloperate-glkernel/include/gloperate-glkernel/stages/MultiFrameControlStage.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/gloperate-glkernel/include/gloperate-glkernel/stages/NoiseKernelStage.h
+++ b/source/gloperate-glkernel/include/gloperate-glkernel/stages/NoiseKernelStage.h
@@ -71,7 +71,7 @@ public:
 protected:
     // Virtual Stage interface
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void resizeKernel();

--- a/source/gloperate-glkernel/include/gloperate-glkernel/stages/TransparencyKernelStage.h
+++ b/source/gloperate-glkernel/include/gloperate-glkernel/stages/TransparencyKernelStage.h
@@ -71,7 +71,7 @@ public:
 protected:
     // Virtual Stage interface
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper function
     void regenerateKernel();

--- a/source/gloperate-glkernel/source/stages/DiscDistributionKernelStage.cpp
+++ b/source/gloperate-glkernel/source/stages/DiscDistributionKernelStage.cpp
@@ -64,13 +64,8 @@ void DiscDistributionKernelStage::onContextInit(gloperate::AbstractGLContext *)
 }
 
 
-void DiscDistributionKernelStage::onProcess(gloperate::AbstractGLContext * context)
+void DiscDistributionKernelStage::onProcess()
 {
-    if (!m_texture)
-    {
-        onContextInit(context);
-    }
-
     bool regenKernel = *regenerate;
     if (*kernelSize != m_kernel.extent().x)
     {

--- a/source/gloperate-glkernel/source/stages/HemisphereDistributionKernelStage.cpp
+++ b/source/gloperate-glkernel/source/stages/HemisphereDistributionKernelStage.cpp
@@ -42,13 +42,8 @@ void HemisphereDistributionKernelStage::onContextInit(gloperate::AbstractGLConte
 }
 
 
-void HemisphereDistributionKernelStage::onProcess(gloperate::AbstractGLContext * context)
+void HemisphereDistributionKernelStage::onProcess()
 {
-    if (!m_texture)
-    {
-        onContextInit(context);
-    }
-
     bool regenKernel = *regenerate;
     if (*kernelSize != m_kernel.extent().x)
     {

--- a/source/gloperate-glkernel/source/stages/MultiFrameAggregationPipeline.cpp
+++ b/source/gloperate-glkernel/source/stages/MultiFrameAggregationPipeline.cpp
@@ -74,14 +74,14 @@ MultiFrameAggregationPipeline::~MultiFrameAggregationPipeline()
 {
 }
 
-void MultiFrameAggregationPipeline::onProcess(gloperate::AbstractGLContext * context)
+void MultiFrameAggregationPipeline::onProcess()
 {
     if (!m_frameRenderStage)
     {
         return;
     }
 
-    Pipeline::onProcess(context);
+    Pipeline::onProcess();
 }
 
 void MultiFrameAggregationPipeline::setFrameRenderer(gloperate::RenderInterface & interface)

--- a/source/gloperate-glkernel/source/stages/MultiFrameAggregationStage.cpp
+++ b/source/gloperate-glkernel/source/stages/MultiFrameAggregationStage.cpp
@@ -76,7 +76,7 @@ void MultiFrameAggregationStage::onContextInit(gloperate::AbstractGLContext * /*
     setupProgram();
 }
 
-void MultiFrameAggregationStage::onProcess(gloperate::AbstractGLContext * /*context*/)
+void MultiFrameAggregationStage::onProcess()
 {
     if (!(*texture))
         return;

--- a/source/gloperate-glkernel/source/stages/MultiFrameControlStage.cpp
+++ b/source/gloperate-glkernel/source/stages/MultiFrameControlStage.cpp
@@ -30,7 +30,7 @@ MultiFrameControlStage::~MultiFrameControlStage()
 {
 }
 
-void MultiFrameControlStage::onProcess(gloperate::AbstractGLContext *)
+void MultiFrameControlStage::onProcess()
 {
     m_currentFrame++;
 

--- a/source/gloperate-glkernel/source/stages/NoiseKernelStage.cpp
+++ b/source/gloperate-glkernel/source/stages/NoiseKernelStage.cpp
@@ -39,13 +39,8 @@ void NoiseKernelStage::onContextInit(gloperate::AbstractGLContext *)
 }
 
 
-void NoiseKernelStage::onProcess(gloperate::AbstractGLContext * context)
+void NoiseKernelStage::onProcess()
 {
-    if (!m_texture)
-    {
-        onContextInit(context);
-    }
-
     bool regen = *regenerate;
 
     if (*dimensions != glm::ivec3(m_kernel.extent()))

--- a/source/gloperate-glkernel/source/stages/TransparencyKernelStage.cpp
+++ b/source/gloperate-glkernel/source/stages/TransparencyKernelStage.cpp
@@ -36,13 +36,8 @@ void TransparencyKernelStage::onContextInit(gloperate::AbstractGLContext *)
 }
 
 
-void TransparencyKernelStage::onProcess(gloperate::AbstractGLContext * context)
+void TransparencyKernelStage::onProcess()
 {
-    if (!m_texture)
-    {
-        onContextInit(context);
-    }
-
     if (*regenerate)
     {
         regenerateKernel();

--- a/source/gloperate-text/include/gloperate-text/stages/FontImporterStage.h
+++ b/source/gloperate-text/include/gloperate-text/stages/FontImporterStage.h
@@ -30,7 +30,7 @@ public:
 
 
 protected:
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/gloperate-text/include/gloperate-text/stages/GlyphPreparationStage.h
+++ b/source/gloperate-text/include/gloperate-text/stages/GlyphPreparationStage.h
@@ -36,7 +36,7 @@ public:
 protected:
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/gloperate-text/include/gloperate-text/stages/GlyphRenderStage.h
+++ b/source/gloperate-text/include/gloperate-text/stages/GlyphRenderStage.h
@@ -45,7 +45,7 @@ public:
 protected:
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(gloperate::AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/gloperate-text/source/stages/FontImporterStage.cpp
+++ b/source/gloperate-text/source/stages/FontImporterStage.cpp
@@ -24,7 +24,7 @@ FontImporterStage::~FontImporterStage()
 }
 
 
-void FontImporterStage::onProcess(gloperate::AbstractGLContext *)
+void FontImporterStage::onProcess()
 {
     auto newFont = std::unique_ptr<FontFace>{ m_environment->resourceManager()->load<FontFace>(fontFilePath.value().path())};
 

--- a/source/gloperate-text/source/stages/GlyphPreparationStage.cpp
+++ b/source/gloperate-text/source/stages/GlyphPreparationStage.cpp
@@ -37,7 +37,7 @@ void GlyphPreparationStage::onContextDeinit(gloperate::AbstractGLContext * /*con
 }
 
 
-void GlyphPreparationStage::onProcess(gloperate::AbstractGLContext * /*context*/)
+void GlyphPreparationStage::onProcess()
 {
     // get total number of glyphs
     auto numGlyphs = std::size_t{ 0 };

--- a/source/gloperate-text/source/stages/GlyphRenderStage.cpp
+++ b/source/gloperate-text/source/stages/GlyphRenderStage.cpp
@@ -56,7 +56,7 @@ void GlyphRenderStage::onContextDeinit(gloperate::AbstractGLContext *)
 }
 
 
-void GlyphRenderStage::onProcess(gloperate::AbstractGLContext *)
+void GlyphRenderStage::onProcess()
 {
     gl::glViewport(viewport->x, viewport->y, viewport->z, viewport->w);
 

--- a/source/gloperate/include/gloperate/pipeline/Pipeline.h
+++ b/source/gloperate/include/gloperate/pipeline/Pipeline.h
@@ -147,7 +147,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
     virtual void onInputValueChanged(AbstractSlot * slot) override;
     virtual void onOutputRequiredChanged(AbstractSlot * slot) override;
 

--- a/source/gloperate/include/gloperate/pipeline/Stage.h
+++ b/source/gloperate/include/gloperate/pipeline/Stage.h
@@ -178,12 +178,9 @@ public:
     *  @brief
     *    Process stage
     *
-    *  @param[in] context
-    *    OpenGL context that is current (must NOT null!)
-    *
     *  @see onProcess
     */
-    void process(AbstractGLContext * context);
+    void process();
 
     /**
     *  @brief
@@ -630,9 +627,6 @@ protected:
     *    At this point, the stage is expected to process its
     *    inputs and create its output data.
     *
-    *  @param[in] context
-    *    OpenGL context that is current (must NOT be null!)
-    *
     *  @remarks
     *    The provided OpenGL context is already made current by
     *    the caller of this function, i.e., the viewer or parent
@@ -641,7 +635,7 @@ protected:
     *    manages its own context, it needs to rebind the former
     *    context at the end of its execution.
     */
-    virtual void onProcess(AbstractGLContext * context);
+    virtual void onProcess();
 
     /**
     *  @brief

--- a/source/gloperate/include/gloperate/stages/base/BasicFramebufferStage.h
+++ b/source/gloperate/include/gloperate/stages/base/BasicFramebufferStage.h
@@ -81,7 +81,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void rebuildFBO();

--- a/source/gloperate/include/gloperate/stages/base/BlitStage.h
+++ b/source/gloperate/include/gloperate/stages/base/BlitStage.h
@@ -63,7 +63,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 };
 
 

--- a/source/gloperate/include/gloperate/stages/base/ColorGradientSelectionStage.h
+++ b/source/gloperate/include/gloperate/stages/base/ColorGradientSelectionStage.h
@@ -68,7 +68,7 @@ protected:
     *  @remarks
     *    Overriden
     */
-    virtual void onProcess(gloperate::AbstractGLContext * /*context*/) override;
+    virtual void onProcess() override;
 };
 
 

--- a/source/gloperate/include/gloperate/stages/base/ColorGradientTextureStage.h
+++ b/source/gloperate/include/gloperate/stages/base/ColorGradientTextureStage.h
@@ -71,7 +71,7 @@ protected:
     *  @remarks
     *    Overriden
     */
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 protected:
     // Data

--- a/source/gloperate/include/gloperate/stages/base/FramebufferStage.h
+++ b/source/gloperate/include/gloperate/stages/base/FramebufferStage.h
@@ -79,7 +79,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void rebuildFBO();

--- a/source/gloperate/include/gloperate/stages/base/MixerStage.h
+++ b/source/gloperate/include/gloperate/stages/base/MixerStage.h
@@ -82,7 +82,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
     virtual void onInputValueChanged(AbstractSlot * slot) override;
 
     // Helper functions

--- a/source/gloperate/include/gloperate/stages/base/ProceduralTextureStage.h
+++ b/source/gloperate/include/gloperate/stages/base/ProceduralTextureStage.h
@@ -61,7 +61,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void createTexture();

--- a/source/gloperate/include/gloperate/stages/base/ProgramStage.h
+++ b/source/gloperate/include/gloperate/stages/base/ProgramStage.h
@@ -71,7 +71,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
     virtual void onContextInit(AbstractGLContext * content) override;
     virtual void onContextDeinit(AbstractGLContext * content) override;
 

--- a/source/gloperate/include/gloperate/stages/base/RasterizationStage.h
+++ b/source/gloperate/include/gloperate/stages/base/RasterizationStage.h
@@ -90,7 +90,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
     void onContextInit(AbstractGLContext * content) override;
 
 protected:

--- a/source/gloperate/include/gloperate/stages/base/RenderPassStage.h
+++ b/source/gloperate/include/gloperate/stages/base/RenderPassStage.h
@@ -101,7 +101,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
     void onContextInit(AbstractGLContext * content) override;
 
 protected:

--- a/source/gloperate/include/gloperate/stages/base/ShaderStage.h
+++ b/source/gloperate/include/gloperate/stages/base/ShaderStage.h
@@ -69,7 +69,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 protected:
     std::unique_ptr<globjects::Shader> m_shader; ///< Shader object

--- a/source/gloperate/include/gloperate/stages/base/SplitStage.h
+++ b/source/gloperate/include/gloperate/stages/base/SplitStage.h
@@ -83,7 +83,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
     virtual void onInputValueChanged(AbstractSlot * slot) override;
 
     // Helper functions

--- a/source/gloperate/include/gloperate/stages/base/TextureLoadStage.h
+++ b/source/gloperate/include/gloperate/stages/base/TextureLoadStage.h
@@ -68,7 +68,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void loadTexture();

--- a/source/gloperate/include/gloperate/stages/base/TextureStage.h
+++ b/source/gloperate/include/gloperate/stages/base/TextureStage.h
@@ -80,7 +80,7 @@ protected:
     // Virtual Stage interface
     virtual void onContextInit(gloperate::AbstractGLContext * context) override;
     virtual void onContextDeinit(AbstractGLContext * context) override;
-    virtual void onProcess(gloperate::AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
 
 protected:

--- a/source/gloperate/include/gloperate/stages/lights/LightBufferTextureStage.h
+++ b/source/gloperate/include/gloperate/stages/lights/LightBufferTextureStage.h
@@ -77,7 +77,7 @@ public:
 protected:
     // Virtual Stage interface
     virtual void onContextInit(AbstractGLContext * context) override;
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 
     // Helper functions
     void setupBufferTextures();

--- a/source/gloperate/include/gloperate/stages/lights/LightCreationStage.h
+++ b/source/gloperate/include/gloperate/stages/lights/LightCreationStage.h
@@ -64,7 +64,7 @@ public:
 
 protected:
     // Virtual Stage interface
-    virtual void onProcess(AbstractGLContext * context) override;
+    virtual void onProcess() override;
 };
 
 

--- a/source/gloperate/source/base/Canvas.cpp
+++ b/source/gloperate/source/base/Canvas.cpp
@@ -258,7 +258,7 @@ void Canvas::render(globjects::Framebuffer * targetFBO)
     if (slotTargetFBO)
     {
         slotTargetFBO->setValue(targetFBO);
-        m_renderStage->process(m_openGLContext);
+        m_renderStage->process();
     }
 }
 

--- a/source/gloperate/source/pipeline/Pipeline.cpp
+++ b/source/gloperate/source/pipeline/Pipeline.cpp
@@ -240,7 +240,7 @@ void Pipeline::onContextDeinit(AbstractGLContext * context)
     }
 }
 
-void Pipeline::onProcess(AbstractGLContext * context)
+void Pipeline::onProcess()
 {
     if (!m_sorted) {
         sortStages();
@@ -249,7 +249,7 @@ void Pipeline::onProcess(AbstractGLContext * context)
     for (auto stage : m_stages)
     {
         if (stage->needsProcessing()) {
-            stage->process(context);
+            stage->process();
         }
         else
         {

--- a/source/gloperate/source/pipeline/Stage.cpp
+++ b/source/gloperate/source/pipeline/Stage.cpp
@@ -109,10 +109,10 @@ void Stage::deinitContext(AbstractGLContext * context)
     onContextDeinit(context);
 }
 
-void Stage::process(AbstractGLContext * context)
+void Stage::process()
 {
     debug(1, "gloperate") << this->qualifiedName() << ": processing";
-    onProcess(context);
+    onProcess();
 
     for (auto input : m_inputs)
     {
@@ -472,7 +472,7 @@ void Stage::onContextDeinit(AbstractGLContext *)
 {
 }
 
-void Stage::onProcess(AbstractGLContext *)
+void Stage::onProcess()
 {
 }
 

--- a/source/gloperate/source/stages/base/BasicFramebufferStage.cpp
+++ b/source/gloperate/source/stages/base/BasicFramebufferStage.cpp
@@ -43,7 +43,7 @@ void BasicFramebufferStage::onContextDeinit(AbstractGLContext *)
     m_fbo          = nullptr;
 }
 
-void BasicFramebufferStage::onProcess(AbstractGLContext *)
+void BasicFramebufferStage::onProcess()
 {
     // Check if FBO needs to be rebuilt
     if (!fbo.isValid())

--- a/source/gloperate/source/stages/base/BlitStage.cpp
+++ b/source/gloperate/source/stages/base/BlitStage.cpp
@@ -21,7 +21,7 @@ BlitStage::BlitStage(Environment * environment, const std::string & name)
 {
 }
 
-void BlitStage::onProcess(AbstractGLContext * /*context*/)
+void BlitStage::onProcess()
 {
     globjects::Framebuffer * srcFBO = *sourceFBO;
 

--- a/source/gloperate/source/stages/base/ColorGradientSelectionStage.cpp
+++ b/source/gloperate/source/stages/base/ColorGradientSelectionStage.cpp
@@ -20,7 +20,7 @@ ColorGradientSelectionStage::ColorGradientSelectionStage(gloperate::Environment 
 {
 }
 
-void ColorGradientSelectionStage::onProcess(gloperate::AbstractGLContext * /*context*/)
+void ColorGradientSelectionStage::onProcess()
 {
     gradientIndex.setValue(gradients->indexOf(*gradientName));
     gradient.setValue(gradients->at(*gradientName));

--- a/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
+++ b/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
@@ -19,7 +19,7 @@ ColorGradientTextureStage::ColorGradientTextureStage(gloperate::Environment * en
 {
 }
 
-void ColorGradientTextureStage::onProcess(gloperate::AbstractGLContext * /*context*/)
+void ColorGradientTextureStage::onProcess()
 {
     if(!m_gradientTexture)
     {

--- a/source/gloperate/source/stages/base/FramebufferStage.cpp
+++ b/source/gloperate/source/stages/base/FramebufferStage.cpp
@@ -35,7 +35,7 @@ void FramebufferStage::onContextDeinit(AbstractGLContext *)
 {
 }
 
-void FramebufferStage::onProcess(AbstractGLContext *)
+void FramebufferStage::onProcess()
 {
     // Check if FBO needs to be rebuilt
     if (!fbo.isValid())

--- a/source/gloperate/source/stages/base/MixerStage.cpp
+++ b/source/gloperate/source/stages/base/MixerStage.cpp
@@ -64,7 +64,7 @@ void MixerStage::onContextDeinit(AbstractGLContext *)
     m_program = nullptr;
 }
 
-void MixerStage::onProcess(AbstractGLContext *)
+void MixerStage::onProcess()
 {
     // Check if geometry needs to be built
     if (!m_vao.get())

--- a/source/gloperate/source/stages/base/ProceduralTextureStage.cpp
+++ b/source/gloperate/source/stages/base/ProceduralTextureStage.cpp
@@ -31,7 +31,7 @@ void ProceduralTextureStage::onContextDeinit(AbstractGLContext *)
 {
 }
 
-void ProceduralTextureStage::onProcess(AbstractGLContext *)
+void ProceduralTextureStage::onProcess()
 {
     // Check if texture needs to be rebuilt
     if (!texture.isValid())

--- a/source/gloperate/source/stages/base/ProgramStage.cpp
+++ b/source/gloperate/source/stages/base/ProgramStage.cpp
@@ -48,7 +48,7 @@ void ProgramStage::onContextDeinit(AbstractGLContext *)
     m_program = nullptr;
 }
 
-void ProgramStage::onProcess(AbstractGLContext *)
+void ProgramStage::onProcess()
 {
     for (auto shader : m_program->shaders()) {
         m_program->detach(shader);

--- a/source/gloperate/source/stages/base/RasterizationStage.cpp
+++ b/source/gloperate/source/stages/base/RasterizationStage.cpp
@@ -41,7 +41,7 @@ void RasterizationStage::onContextInit(AbstractGLContext *)
 {
 }
 
-void RasterizationStage::onProcess(AbstractGLContext *)
+void RasterizationStage::onProcess()
 {
     if (!*rasterize)
     {

--- a/source/gloperate/source/stages/base/RenderPassStage.cpp
+++ b/source/gloperate/source/stages/base/RenderPassStage.cpp
@@ -60,7 +60,7 @@ void RenderPassStage::onContextInit(AbstractGLContext *)
     m_renderPass->stateBefore()->depthMask(gl::GL_TRUE);
 }
 
-void RenderPassStage::onProcess(AbstractGLContext *)
+void RenderPassStage::onProcess()
 {
     m_renderPass->setGeometry((*drawable));
     m_renderPass->setProgram((*program));

--- a/source/gloperate/source/stages/base/ShaderStage.cpp
+++ b/source/gloperate/source/stages/base/ShaderStage.cpp
@@ -27,7 +27,7 @@ ShaderStage::~ShaderStage()
 {
 }
 
-void ShaderStage::onProcess(AbstractGLContext *)
+void ShaderStage::onProcess()
 {
     m_shader = std::unique_ptr<globjects::Shader>(environment()->resourceManager()->load<globjects::Shader>((*filePath).path()));
     shader.setValue(m_shader.get());

--- a/source/gloperate/source/stages/base/SplitStage.cpp
+++ b/source/gloperate/source/stages/base/SplitStage.cpp
@@ -59,7 +59,7 @@ void SplitStage::onContextDeinit(AbstractGLContext *)
 {
 }
 
-void SplitStage::onProcess(AbstractGLContext *)
+void SplitStage::onProcess()
 {
     // Check if geometry needs to be built
     if (!m_vao.get())

--- a/source/gloperate/source/stages/base/TextureLoadStage.cpp
+++ b/source/gloperate/source/stages/base/TextureLoadStage.cpp
@@ -33,7 +33,7 @@ void TextureLoadStage::onContextDeinit(AbstractGLContext *)
     m_texture = nullptr;
 }
 
-void TextureLoadStage::onProcess(AbstractGLContext *)
+void TextureLoadStage::onProcess()
 {
     // Check if texture needs to be rebuilt
     if (!texture.isValid())

--- a/source/gloperate/source/stages/base/TextureStage.cpp
+++ b/source/gloperate/source/stages/base/TextureStage.cpp
@@ -56,7 +56,7 @@ void TextureStage::onContextDeinit(AbstractGLContext *)
     m_renderTarget.reset(nullptr);
 }
 
-void TextureStage::onProcess(gloperate::AbstractGLContext *)
+void TextureStage::onProcess()
 {
     // Check if texture has been created successfully
     if (!m_texture.get())

--- a/source/gloperate/source/stages/lights/LightBufferTextureStage.cpp
+++ b/source/gloperate/source/stages/lights/LightBufferTextureStage.cpp
@@ -43,7 +43,7 @@ void LightBufferTextureStage::onContextInit(AbstractGLContext * /*context*/)
 {
 }
 
-void LightBufferTextureStage::onProcess(AbstractGLContext * /*context*/)
+void LightBufferTextureStage::onProcess()
 {
     if (!colorTypeData.isValid() || !positionData.isValid() || !attenuationData.isValid())
     {

--- a/source/gloperate/source/stages/lights/LightCreationStage.cpp
+++ b/source/gloperate/source/stages/lights/LightCreationStage.cpp
@@ -23,7 +23,7 @@ LightCreationStage::~LightCreationStage()
 {
 }
 
-void LightCreationStage::onProcess(AbstractGLContext * /*context*/)
+void LightCreationStage::onProcess()
 {
     light.setValue(Light{LightType(*type), *color, *position, *attenuationCoefficients});
 }


### PR DESCRIPTION
If a stage should really need it (it shouldn't), it can save it in onContextInit().