### PR TITLE
Fix Basic Functionality of Color Gradients

### DIFF
--- a/source/gloperate/source/rendering/ColorGradientPreparation.cpp
+++ b/source/gloperate/source/rendering/ColorGradientPreparation.cpp
@@ -92,8 +92,8 @@ void ColorGradientPreparation::fillPixmaps(std::vector<std::vector<unsigned char
 
 void ColorGradientPreparation::configureProperty(cppexpose::AbstractProperty * property) const
 {
+    property->setOption("choices", cppexpose::Variant::arrayFromValues(names()));
     property->setOption("pixmapSize", cppexpose::Variant::fromValue(iconSize()));
-    property->setOption("choices", cppexpose::Variant::fromValue(names()));
     property->setOption("pixmaps", cppexpose::Variant::fromValue(pixmaps()));
 }
 

--- a/source/gloperate/source/rendering/ColorGradientPreparation.cpp
+++ b/source/gloperate/source/rendering/ColorGradientPreparation.cpp
@@ -94,7 +94,7 @@ void ColorGradientPreparation::configureProperty(cppexpose::AbstractProperty * p
 {
     property->setOption("choices", cppexpose::Variant::arrayFromValues(names()));
     property->setOption("pixmapSize", cppexpose::Variant::fromValue(iconSize()));
-    property->setOption("pixmaps", cppexpose::Variant::fromValue(pixmaps()));
+    property->setOption("pixmaps", cppexpose::Variant::arrayFromValues(pixmaps()));
 }
 
 


### PR DESCRIPTION
This makes the ColorGradient choices appear in the desired format for the qmltoolbox EnumEditor.  Pixmaps are also passed in this manner, but are supported yet, this depends on changes in qmltoolbox.

This depends on [PR 41 in cppexpose](https://github.com/cginternals/cppexpose/pull/41).