### PR TITLE
Add functions to combine multiple gradient lists in one texture

### DIFF
--- a/source/gloperate/include/gloperate/rendering/ColorGradientList.h
+++ b/source/gloperate/include/gloperate/rendering/ColorGradientList.h
@@ -203,6 +203,20 @@ public:
     */
     std::unique_ptr<globjects::Texture> generateTexture(size_t numPixels) const;
 
+    /**
+    *  @brief
+    *    Get a texture containing all gradients in this and other ColorGradientLists
+    *
+    *  @param[in] numPixels
+    *    Number of pixels for each gradient
+    *  @param[in] otherLists
+    *    Additional ColorGradientLists
+    *
+    *  @return
+    *    Texture containing all gradients (dimensions: numPixels x total size of all lists())
+    */
+    std::unique_ptr<globjects::Texture> generateCompositeTexture(size_t numPixels, const std::vector<ColorGradientList *> & otherLists) const;
+
 
 protected:
     std::map<std::string, std::unique_ptr<AbstractColorGradient>> m_gradients; ///< The list of gradients with their name as lookup key

--- a/source/gloperate/include/gloperate/rendering/ColorGradientList.h
+++ b/source/gloperate/include/gloperate/rendering/ColorGradientList.h
@@ -39,6 +39,21 @@ class GLOPERATE_API ColorGradientList
 public:
     /**
     *  @brief
+    *    Generate a texture from multiple ColorGradientLists
+    *
+    *  @param[in] numPixels
+    *    Number of pixels for each gradient
+    *  @param[in] colorGradientLists
+    *    All color gradient lists
+    *
+    *  @return
+    *    Texture containing all gradients (dimensions: numPixels x sum of all list sizes)
+    */
+    static std::unique_ptr<globjects::Texture> generateTexture(size_t numPixels, const std::vector<ColorGradientList *> & colorGradientLists);
+
+public:
+    /**
+    *  @brief
     *    Constructor
     *
     *    Construct an empty color gradient list.
@@ -178,18 +193,17 @@ public:
 
     /**
     *  @brief
-    *    Get a vector containing pixel data for all gradients
+    *    Writes raw pixel data of all gradients into an array or a vector
     *
     *  @param[in] numColors
     *    Number of pixels for each gradient
-    *
-    *  @return
-    *    Vector containing pixel data for all gradients (dimensions: numPixels x size())
+    *  @param[in] start
+    *    Start position, size needs to be sufficient for writing all data
     *
     *  @see
     *    AbstractColorGradient::pixelData()
     */
-    std::vector<unsigned char> pixelData(size_t numPixels) const;
+    void appendPixelData(size_t numPixels, unsigned char * start) const;
 
     /**
     *  @brief
@@ -202,21 +216,6 @@ public:
     *    Texture containing all gradients (dimensions: numPixels x size())
     */
     std::unique_ptr<globjects::Texture> generateTexture(size_t numPixels) const;
-
-    /**
-    *  @brief
-    *    Get a texture containing all gradients in this and other ColorGradientLists
-    *
-    *  @param[in] numPixels
-    *    Number of pixels for each gradient
-    *  @param[in] otherLists
-    *    Additional ColorGradientLists
-    *
-    *  @return
-    *    Texture containing all gradients (dimensions: numPixels x total size of all lists())
-    */
-    std::unique_ptr<globjects::Texture> generateCompositeTexture(size_t numPixels, const std::vector<ColorGradientList *> & otherLists) const;
-
 
 protected:
     std::map<std::string, std::unique_ptr<AbstractColorGradient>> m_gradients; ///< The list of gradients with their name as lookup key

--- a/source/gloperate/include/gloperate/rendering/ColorGradientList.h
+++ b/source/gloperate/include/gloperate/rendering/ColorGradientList.h
@@ -41,15 +41,16 @@ public:
     *  @brief
     *    Generate a texture from multiple ColorGradientLists
     *
-    *  @param[in] numPixels
-    *    Number of pixels for each gradient
     *  @param[in] colorGradientLists
     *    All color gradient lists
+    *  @param[in] numPixels
+    *    Number of pixels for each gradient
     *
     *  @return
     *    Texture containing all gradients (dimensions: numPixels x sum of all list sizes)
     */
-    static std::unique_ptr<globjects::Texture> generateTexture(size_t numPixels, const std::vector<ColorGradientList *> & colorGradientLists);
+    static std::unique_ptr<globjects::Texture> generateTexture(const std::vector<ColorGradientList *> & colorGradientLists, size_t numPixels);
+
 
 public:
     /**

--- a/source/gloperate/include/gloperate/stages/base/ColorGradientStage.h
+++ b/source/gloperate/include/gloperate/stages/base/ColorGradientStage.h
@@ -43,6 +43,7 @@ public:
 
     // Outputs
     Output<ColorGradientList *> gradients; ///< List of color gradients
+    Output<unsigned int>        size;      ///< Number of loaded color gradients
 
 
 public:

--- a/source/gloperate/source/rendering/ColorGradientList.cpp
+++ b/source/gloperate/source/rendering/ColorGradientList.cpp
@@ -126,57 +126,51 @@ int ColorGradientList::indexOf(const std::string & name) const
     return static_cast<int>(std::distance(m_gradients.begin(), it));
 }
 
-std::vector<unsigned char> ColorGradientList::pixelData(size_t numPixels) const
+void ColorGradientList::appendPixelData(size_t numPixels, unsigned char * start) const
 {
-    std::vector<unsigned char> data(numPixels * m_gradients.size() * sizeof(std::uint32_t));
-
     size_t i = 0;
     for (const auto & pair : m_gradients)
     {
         const auto & gradient = pair.second;
 
-        gradient->fillPixelData(&data[i * numPixels * sizeof(std::uint32_t)], numPixels);
+        gradient->fillPixelData(start + (i * numPixels * sizeof(std::uint32_t)), numPixels);
 
         ++i;
     }
-
-    return data;
 }
 
 std::unique_ptr<globjects::Texture> ColorGradientList::generateTexture(size_t numPixels) const
 {
     auto texture = globjects::Texture::createDefault();
 
-    std::vector<unsigned char> data = pixelData(numPixels);
+    std::vector<unsigned char> data(numPixels * m_gradients.size() * sizeof(std::uint32_t));
+    appendPixelData(numPixels, &(data[0]));
 
     texture->image2D(0, gl::GL_RGBA, numPixels, m_gradients.size(), 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
 
     return texture;
 }
 
-std::unique_ptr<globjects::Texture> ColorGradientList::generateCompositeTexture(size_t numPixels, const std::vector<ColorGradientList *> & otherLists) const
+std::unique_ptr<globjects::Texture> ColorGradientList::generateTexture(size_t numPixels, const std::vector<ColorGradientList *> & colorGradientLists)
 {
     auto texture = globjects::Texture::createDefault();
 
-    size_t totalSize = m_gradients.size();
-    for (auto other : otherLists)
+    size_t numberOfGradients = 0;
+    for (auto list : colorGradientLists)
     {
-        totalSize += other->size();
+        numberOfGradients += list->size();
+    }
+    size_t gradientSize = numPixels * sizeof(std::uint32_t);
+
+    std::vector<unsigned char> data(numberOfGradients * gradientSize);
+    size_t offset = 0;
+    for (auto list : colorGradientLists)
+    {
+        list->appendPixelData(numPixels, &(data[offset * gradientSize]));
+        offset += list->size();
     }
 
-    std::vector<unsigned char> data;
-    data.reserve(numPixels * totalSize);
-
-    std::vector<unsigned char> partialData = pixelData(numPixels);
-    data.insert(data.end(), partialData.begin(), partialData.end());
-
-    for (auto other : otherLists)
-    {
-        partialData = other->pixelData(numPixels);
-        data.insert(data.end(), partialData.begin(), partialData.end());
-    }
-
-    texture->image2D(0, gl::GL_RGBA, numPixels, totalSize, 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
+    texture->image2D(0, gl::GL_RGBA, numPixels, numberOfGradients, 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
 
     return texture;
 }

--- a/source/gloperate/source/rendering/ColorGradientList.cpp
+++ b/source/gloperate/source/rendering/ColorGradientList.cpp
@@ -17,6 +17,30 @@ namespace gloperate
 {
 
 
+std::unique_ptr<globjects::Texture> ColorGradientList::generateTexture(const std::vector<ColorGradientList *> & colorGradientLists, size_t numPixels)
+{
+    auto texture = globjects::Texture::createDefault();
+
+    size_t numberOfGradients = 0;
+    for (auto list : colorGradientLists)
+    {
+        numberOfGradients += list->size();
+    }
+    size_t gradientSize = numPixels * sizeof(std::uint32_t);
+
+    std::vector<unsigned char> data(numberOfGradients * gradientSize);
+    size_t offset = 0;
+    for (auto list : colorGradientLists)
+    {
+        list->appendPixelData(numPixels, &(data[offset * gradientSize]));
+        offset += list->size();
+    }
+
+    texture->image2D(0, gl::GL_RGBA, numPixels, numberOfGradients, 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
+
+    return texture;
+}
+
 ColorGradientList::ColorGradientList()
 {
 }
@@ -147,30 +171,6 @@ std::unique_ptr<globjects::Texture> ColorGradientList::generateTexture(size_t nu
     appendPixelData(numPixels, &(data[0]));
 
     texture->image2D(0, gl::GL_RGBA, numPixels, m_gradients.size(), 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
-
-    return texture;
-}
-
-std::unique_ptr<globjects::Texture> ColorGradientList::generateTexture(size_t numPixels, const std::vector<ColorGradientList *> & colorGradientLists)
-{
-    auto texture = globjects::Texture::createDefault();
-
-    size_t numberOfGradients = 0;
-    for (auto list : colorGradientLists)
-    {
-        numberOfGradients += list->size();
-    }
-    size_t gradientSize = numPixels * sizeof(std::uint32_t);
-
-    std::vector<unsigned char> data(numberOfGradients * gradientSize);
-    size_t offset = 0;
-    for (auto list : colorGradientLists)
-    {
-        list->appendPixelData(numPixels, &(data[offset * gradientSize]));
-        offset += list->size();
-    }
-
-    texture->image2D(0, gl::GL_RGBA, numPixels, numberOfGradients, 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
 
     return texture;
 }

--- a/source/gloperate/source/rendering/ColorGradientList.cpp
+++ b/source/gloperate/source/rendering/ColorGradientList.cpp
@@ -154,5 +154,32 @@ std::unique_ptr<globjects::Texture> ColorGradientList::generateTexture(size_t nu
     return texture;
 }
 
+std::unique_ptr<globjects::Texture> ColorGradientList::generateCompositeTexture(size_t numPixels, const std::vector<ColorGradientList *> & otherLists) const
+{
+    auto texture = globjects::Texture::createDefault();
+
+    size_t totalSize = m_gradients.size();
+    for (auto other : otherLists)
+    {
+        totalSize += other->size();
+    }
+
+    std::vector<unsigned char> data;
+    data.reserve(numPixels * totalSize);
+
+    std::vector<unsigned char> partialData = pixelData(numPixels);
+    data.insert(data.end(), partialData.begin(), partialData.end());
+
+    for (auto other : otherLists)
+    {
+        partialData = other->pixelData(numPixels);
+        data.insert(data.end(), partialData.begin(), partialData.end());
+    }
+
+    texture->image2D(0, gl::GL_RGBA, numPixels, totalSize, 0, gl::GL_BGRA, gl::GL_UNSIGNED_BYTE, data.data());
+
+    return texture;
+}
+
 
 } // namespace gloperate

--- a/source/gloperate/source/stages/base/ColorGradientStage.cpp
+++ b/source/gloperate/source/stages/base/ColorGradientStage.cpp
@@ -17,6 +17,7 @@ ColorGradientStage::ColorGradientStage(Environment * environment, const std::str
 : Stage(environment, "ColorGradientStage", name)
 , filePath("filePath", this)
 , gradients("gradients", this)
+, size("size", this, 0)
 {
 }
 
@@ -41,6 +42,7 @@ void ColorGradientStage::onProcess()
 
     // Update outputs
     gradients.setValue(m_colorGradientList.get());
+    size.setValue(m_colorGradientList->size());
 }
 
 

--- a/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
+++ b/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
@@ -37,8 +37,27 @@ void ColorGradientTextureStage::onContextDeinit(AbstractGLContext *)
 
 void ColorGradientTextureStage::onProcess()
 {
-    // Generate texture
-    m_gradientTexture = gradients->generateTexture(*textureWidth);
+    std::vector<ColorGradientList *> additionalGradients;
+
+    for (auto input : inputs())
+    {
+        // Only consider dynamic inputs
+        if (!input->isDynamic())
+            continue;
+
+        if (input->type() == typeid(ColorGradientList *))
+        {
+            additionalGradients.push_back(static_cast<Input<ColorGradientList *> *>(input)->value());
+        }
+    }
+
+    if (additionalGradients.size() == 0)
+    {
+        // Generate texture
+        m_gradientTexture = gradients->generateTexture(*textureWidth);
+    } else {
+        m_gradientTexture = gradients->generateCompositeTexture(*textureWidth, additionalGradients);
+    }
 
     // Update output
     this->texture.setValue(m_gradientTexture.get());

--- a/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
+++ b/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
@@ -37,27 +37,17 @@ void ColorGradientTextureStage::onContextDeinit(AbstractGLContext *)
 
 void ColorGradientTextureStage::onProcess()
 {
-    std::vector<ColorGradientList *> additionalGradients;
+    std::vector<ColorGradientList *> gradientLists;
 
     for (auto input : inputs())
     {
-        // Only consider dynamic inputs
-        if (!input->isDynamic())
-            continue;
-
         if (input->type() == typeid(ColorGradientList *))
         {
-            additionalGradients.push_back(static_cast<Input<ColorGradientList *> *>(input)->value());
+            gradientLists.push_back(static_cast<Input<ColorGradientList *> *>(input)->value());
         }
     }
 
-    if (additionalGradients.size() == 0)
-    {
-        // Generate texture
-        m_gradientTexture = gradients->generateTexture(*textureWidth);
-    } else {
-        m_gradientTexture = gradients->generateCompositeTexture(*textureWidth, additionalGradients);
-    }
+    m_gradientTexture = ColorGradientList::generateTexture(*textureWidth, gradientLists);
 
     // Update output
     this->texture.setValue(m_gradientTexture.get());


### PR DESCRIPTION
We can add dynamic inputs of the type `ColorGradientList *` to a `ColorGradientTextureStage`. This stage then uses the new `generateCompositeTexture` to merge color gradients into one texture. Since the resulting index for all gradient lists except the first is now offset, the `ColorGradientStage` loading these lists now also has a `size` output, which can be used in later stages to account for this offset.