### PR TITLE
Add explicit default value to color demo and remove setting first choice

### DIFF
--- a/source/examples/demo-stages-plugins/ColorGradientDemo.cpp
+++ b/source/examples/demo-stages-plugins/ColorGradientDemo.cpp
@@ -28,7 +28,7 @@ ColorGradientDemo::ColorGradientDemo(Environment * environment, const std::strin
 : Pipeline(environment, "ColorGradientDemo", name)
 , renderInterface(this)
 , colors("colors", this, dataPath() + "/gloperate/gradients/colorbrewer.json")
-, gradient("gradient", this)
+, gradient("gradient", this, "Set1-5")
 , value("value", this, 0.5f)
 , m_trackball(cppassist::make_unique<TrackballStage>(environment, "Trackball"))
 , m_shape(cppassist::make_unique<ShapeStage>(environment, "Shape"))
@@ -73,7 +73,6 @@ ColorGradientDemo::ColorGradientDemo(Environment * environment, const std::strin
     {
         gradient.setOption("choices", cppexpose::Variant::fromVector(gradients->names()));
         gradient.setOption("pixmaps", cppexpose::Variant::fromVector(gradients->pixmaps({ 80, 20 })));
-        gradient.setValue(gradients->gradients().begin()->first);
     });
 
     // Color gradients texture stage


### PR DESCRIPTION
Set a default value instead of overwriting with first choice after loading. Slightly depends on [qmltoolbox #25](https://github.com/cginternals/qmltoolbox/pull/25), which catches possibly invalid default choice.