### PR TITLE
Fix ColorGradientTextureStage compilation

### DIFF
--- a/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
+++ b/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
@@ -47,7 +47,7 @@ void ColorGradientTextureStage::onProcess()
         }
     }
 
-    m_gradientTexture = ColorGradientList::generateTexture(*textureWidth, gradientLists);
+    m_gradientTexture = ColorGradientList::generateTexture(gradientLists, *textureWidth);
 
     // Update output
     this->texture.setValue(m_gradientTexture.get());


### PR DESCRIPTION
  - Fix change in interface by 0dc7e4c5 of #381 not being transferred to ColorGradientTextureStage (order of arguments)