### PR TITLE
[WIP] Macos fixes

### DIFF
--- a/source/examples/demo-stages-plugins/ShapeDemo.cpp
+++ b/source/examples/demo-stages-plugins/ShapeDemo.cpp
@@ -148,7 +148,7 @@ ShapeDemo::ShapeDemo(Environment * environment, const std::string & name)
     /* Hack Start */
     shapeColorOutput->valueInvalidated.onFire([=]() {
         m_clear->renderInterface.colorRenderTargetOutput(0)->invalidate();
-        m_clear->renderInterface.depthRenderTargetOutput(0)->invalidate();
+        // m_clear->renderInterface.depthRenderTargetOutput(0)->invalidate();
     });
     /* Hack End */
 

--- a/source/gloperate-qtquick/source/TextureItemRenderer_ogl.cpp
+++ b/source/gloperate-qtquick/source/TextureItemRenderer_ogl.cpp
@@ -66,9 +66,10 @@ void TextureItemRenderer::renderTexture()
     if (!slot) return;
 
     // Check if it is a texture slot
-    if (slot && slot->type() == typeid(globjects::Texture *))
+    auto * textureSlot = dynamic_cast< Slot<globjects::Texture *> * >(slot);
+    if (textureSlot)
     {
-        texture = static_cast< Slot<globjects::Texture *> * >(slot)->value();
+        texture = textureSlot->value();
     }
 
     // Abort if texture is invalid

--- a/source/gloperate/include/gloperate/pipeline/Stage.inl
+++ b/source/gloperate/include/gloperate/pipeline/Stage.inl
@@ -31,16 +31,18 @@ template <typename T>
 std::vector<Input<T> *> Stage::inputs() const
 {
     auto result = std::vector<Input<T> *>{};
-    
+
     // We do not reserve a heuristically derived number of elements as we assume
     // the vector growing strategy would handle most cases efficiently
     // result.reserve(inputs().size() / 2);
-    
+
     for (auto input : inputs())
     {
-        if (input->type() == typeid(T))
+        auto * typedInput = dynamic_cast<Input<T> *>(input);
+
+        if (typedInput)
         {
-            result.push_back(static_cast<Input<T> *>(input));
+            result.push_back(typedInput);
         }
     }
 
@@ -71,16 +73,18 @@ template <typename T>
 std::vector<Output<T> *> Stage::outputs() const
 {
     auto result = std::vector<Output<T> *>{};
-    
+
     // We do not reserve a heuristically derived number of elements as we assume
     // the vector growing strategy would handle most cases efficiently
     // result.reserve(outputs().size() / 2);
-    
+
     for (auto output : outputs())
     {
-        if (output->type() == typeid(T))
+        auto * typedOutput = dynamic_cast<Output<T> *>(output);
+
+        if (typedOutput)
         {
-            result.push_back(static_cast<Output<T> *>(output));
+            result.push_back(typedOutput);
         }
     }
 

--- a/source/gloperate/include/gloperate/pipeline/Stage.inl
+++ b/source/gloperate/include/gloperate/pipeline/Stage.inl
@@ -40,6 +40,13 @@ std::vector<Input<T> *> Stage::inputs() const
     {
         auto * typedInput = dynamic_cast<Input<T> *>(input);
 
+        // [TODO] This workaround is currently needed on macos for Input<cppassist::FilePath>,
+        //        because the dynamic cast fails.
+        if (!typedInput && input->type() == typeid(T))
+        {
+            typedInput = static_cast<Input<T> *>(input);
+        }
+
         if (typedInput)
         {
             result.push_back(typedInput);
@@ -81,6 +88,13 @@ std::vector<Output<T> *> Stage::outputs() const
     for (auto output : outputs())
     {
         auto * typedOutput = dynamic_cast<Output<T> *>(output);
+
+        // [TODO] This workaround is currently needed on macos for Input<cppassist::FilePath>,
+        //        because the dynamic cast fails.
+        if (!typedOutput && output->type() == typeid(T))
+        {
+            typedOutput = static_cast<Output<T> *>(input);
+        }
 
         if (typedOutput)
         {

--- a/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
+++ b/source/gloperate/source/stages/base/ColorGradientTextureStage.cpp
@@ -41,9 +41,10 @@ void ColorGradientTextureStage::onProcess()
 
     for (auto input : inputs())
     {
-        if (input->type() == typeid(ColorGradientList *))
+        auto * typedInput = dynamic_cast<Input<ColorGradientList *> *>(input);
+        if (typedInput)
         {
-            gradientLists.push_back(static_cast<Input<ColorGradientList *> *>(input)->value());
+            gradientLists.push_back(typedInput->value());
         }
     }
 

--- a/source/gloperate/source/stages/base/RenderPassStage.cpp
+++ b/source/gloperate/source/stages/base/RenderPassStage.cpp
@@ -123,16 +123,16 @@ void RenderPassStage::onProcess()
             continue;
 
         // Texture
-        if (input->type() == typeid(globjects::Texture *))
+        if (auto * typedInput = dynamic_cast<Input<globjects::Texture *> *>(input))
         {
             // Get texture
-            globjects::Texture * texture = static_cast<Input<globjects::Texture *> *>(input)->value();
+            globjects::Texture * texture = typedInput->value();
 
             if (!texture)
                 continue;
 
             // Attach texture
-            (*program)->setUniform<int>(input->name(), textureIndex);
+            (*program)->setUniform<int>(typedInput->name(), textureIndex);
             m_renderPass->setTexture(textureIndex, texture);
 
             if (texture->target() == gl::GL_TEXTURE_CUBE_MAP)
@@ -144,10 +144,10 @@ void RenderPassStage::onProcess()
         }
 
         // Shader storage buffer
-        else if (input->type() == typeid(globjects::Buffer *))
+        else if (auto * typedInput = dynamic_cast<Input<globjects::Buffer *> *>(input))
         {
             // Get buffer
-            globjects::Buffer * buffer = static_cast<Input<globjects::Buffer *> *>(input)->value();
+            globjects::Buffer * buffer = typedInput->value();
 
             if (!buffer)
                 continue;
@@ -158,10 +158,10 @@ void RenderPassStage::onProcess()
         }
 
         // Color
-        else if (input->type() == typeid(Color))
+        else if (auto * typedInput = dynamic_cast<Input<Color> *>(input))
         {
             // Get color
-            const Color & color = **(static_cast<Input<Color> *>(input));
+            const Color & color = **typedInput;
 
             // Set color uniform
             (*program)->setUniform<glm::vec4>(input->name(), color.toVec4());
@@ -180,102 +180,102 @@ void RenderPassStage::onProcess()
 
 void RenderPassStage::setUniformValue(globjects::Program * program, AbstractSlot * input)
 {
-    if (input->type() == typeid(float)) {
-        program->setUniform<float>(input->name(), static_cast<Input<float> *>(input)->value());
-    } else if (input->type() == typeid(int)) {
-        program->setUniform<int>(input->name(), static_cast<Input<int> *>(input)->value());
-    } else if (input->type() == typeid(unsigned int)) {
-        program->setUniform<unsigned int>(input->name(), static_cast<Input<unsigned int> *>(input)->value());
-    } else if (input->type() == typeid(bool)) {
-        program->setUniform<bool>(input->name(), static_cast<Input<bool> *>(input)->value());
-    } else if (input->type() == typeid(glm::vec2)) {
-        program->setUniform<glm::vec2>(input->name(), static_cast<Input<glm::vec2> *>(input)->value());
-    } else if (input->type() == typeid(glm::vec3)) {
-        program->setUniform<glm::vec3>(input->name(), static_cast<Input<glm::vec3> *>(input)->value());
-    } else if (input->type() == typeid(glm::vec4)) {
-        program->setUniform<glm::vec4>(input->name(), static_cast<Input<glm::vec4> *>(input)->value());
-    } else if (input->type() == typeid(glm::ivec2)) {
-        program->setUniform<glm::ivec2>(input->name(), static_cast<Input<glm::ivec2> *>(input)->value());
-    } else if (input->type() == typeid(glm::ivec3)) {
-        program->setUniform<glm::ivec3>(input->name(), static_cast<Input<glm::ivec3> *>(input)->value());
-    } else if (input->type() == typeid(glm::ivec4)) {
-        program->setUniform<glm::ivec4>(input->name(), static_cast<Input<glm::ivec4> *>(input)->value());
-    } else if (input->type() == typeid(glm::uvec2)) {
-        program->setUniform<glm::uvec2>(input->name(), static_cast<Input<glm::uvec2> *>(input)->value());
-    } else if (input->type() == typeid(glm::uvec3)) {
-        program->setUniform<glm::uvec3>(input->name(), static_cast<Input<glm::uvec3> *>(input)->value());
-    } else if (input->type() == typeid(glm::uvec4)) {
-        program->setUniform<glm::uvec4>(input->name(), static_cast<Input<glm::uvec4> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat2)) {
-        program->setUniform<glm::mat2>(input->name(), static_cast<Input<glm::mat2> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat3)) {
-        program->setUniform<glm::mat3>(input->name(), static_cast<Input<glm::mat3> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat4)) {
-        program->setUniform<glm::mat4>(input->name(), static_cast<Input<glm::mat4> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat2x3)) {
-        program->setUniform<glm::mat2x3>(input->name(), static_cast<Input<glm::mat2x3> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat3x2)) {
-        program->setUniform<glm::mat3x2>(input->name(), static_cast<Input<glm::mat3x2> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat2x4)) {
-        program->setUniform<glm::mat2x4>(input->name(), static_cast<Input<glm::mat2x4> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat4x2)) {
-        program->setUniform<glm::mat4x2>(input->name(), static_cast<Input<glm::mat4x2> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat3x4)) {
-        program->setUniform<glm::mat3x4>(input->name(), static_cast<Input<glm::mat3x4> *>(input)->value());
-    } else if (input->type() == typeid(glm::mat4x3)) {
-        program->setUniform<glm::mat4x3>(input->name(), static_cast<Input<glm::mat4x3> *>(input)->value());
-    } else if (input->type() == typeid(gl::GLuint64)) {
-        program->setUniform<gl::GLuint64>(input->name(), static_cast<Input<gl::GLuint64> *>(input)->value());
-    } else if (input->type() == typeid(globjects::TextureHandle)) {
-        program->setUniform<globjects::TextureHandle>(input->name(), static_cast<Input<globjects::TextureHandle> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<float>)) {
-        program->setUniform<std::vector<float>>(input->name(), static_cast<Input<std::vector<float>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<int>)) {
-        program->setUniform<std::vector<int>>(input->name(), static_cast<Input<std::vector<int>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<unsigned int>)) {
-        program->setUniform<std::vector<unsigned int>>(input->name(), static_cast<Input<std::vector<unsigned int>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<bool>)) {
-        program->setUniform<std::vector<bool>>(input->name(), static_cast<Input<std::vector<bool>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::vec2>)) {
-        program->setUniform<std::vector<glm::vec2>>(input->name(), static_cast<Input<std::vector<glm::vec2>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::vec3>)) {
-        program->setUniform<std::vector<glm::vec3>>(input->name(), static_cast<Input<std::vector<glm::vec3>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::vec4>)) {
-        program->setUniform<std::vector<glm::vec4>>(input->name(), static_cast<Input<std::vector<glm::vec4>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::ivec2>)) {
-        program->setUniform<std::vector<glm::ivec2>>(input->name(), static_cast<Input<std::vector<glm::ivec2>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::ivec3>)) {
-        program->setUniform<std::vector<glm::ivec3>>(input->name(), static_cast<Input<std::vector<glm::ivec3>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::ivec4>)) {
-        program->setUniform<std::vector<glm::ivec4>>(input->name(), static_cast<Input<std::vector<glm::ivec4>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::uvec2>)) {
-        program->setUniform<std::vector<glm::uvec2>>(input->name(), static_cast<Input<std::vector<glm::uvec2>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::uvec3>)) {
-        program->setUniform<std::vector<glm::uvec3>>(input->name(), static_cast<Input<std::vector<glm::uvec3>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::uvec4>)) {
-        program->setUniform<std::vector<glm::uvec4>>(input->name(), static_cast<Input<std::vector<glm::uvec4>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat2>)) {
-        program->setUniform<std::vector<glm::mat2>>(input->name(), static_cast<Input<std::vector<glm::mat2>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat3>)) {
-        program->setUniform<std::vector<glm::mat3>>(input->name(), static_cast<Input<std::vector<glm::mat3>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat4>)) {
-        program->setUniform<std::vector<glm::mat4>>(input->name(), static_cast<Input<std::vector<glm::mat4>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat2x3>)) {
-        program->setUniform<std::vector<glm::mat2x3>>(input->name(), static_cast<Input<std::vector<glm::mat2x3>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat3x2>)) {
-        program->setUniform<std::vector<glm::mat3x2>>(input->name(), static_cast<Input<std::vector<glm::mat3x2>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat2x4>)) {
-        program->setUniform<std::vector<glm::mat2x4>>(input->name(), static_cast<Input<std::vector<glm::mat2x4>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat4x2>)) {
-        program->setUniform<std::vector<glm::mat4x2>>(input->name(), static_cast<Input<std::vector<glm::mat4x2>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat3x4>)) {
-        program->setUniform<std::vector<glm::mat3x4>>(input->name(), static_cast<Input<std::vector<glm::mat3x4>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<glm::mat4x3>)) {
-        program->setUniform<std::vector<glm::mat4x3>>(input->name(), static_cast<Input<std::vector<glm::mat4x3>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<gl::GLuint64>)) {
-        program->setUniform<std::vector<gl::GLuint64>>(input->name(), static_cast<Input<std::vector<gl::GLuint64>> *>(input)->value());
-    } else if (input->type() == typeid(std::vector<globjects::TextureHandle>)) {
-        program->setUniform<std::vector<globjects::TextureHandle>>(input->name(), static_cast<Input<std::vector<globjects::TextureHandle>> *>(input)->value());
+    if (auto * typedInput = dynamic_cast<Input<float> *>(input)) {
+        program->setUniform<float>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<int> *>(input)) {
+        program->setUniform<int>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<unsigned int> *>(input)) {
+        program->setUniform<unsigned int>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<bool> *>(input)) {
+        program->setUniform<bool>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::vec2> *>(input)) {
+        program->setUniform<glm::vec2>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::vec3> *>(input)) {
+        program->setUniform<glm::vec3>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::vec4> *>(input)) {
+        program->setUniform<glm::vec4>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::ivec2> *>(input)) {
+        program->setUniform<glm::ivec2>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::ivec3> *>(input)) {
+        program->setUniform<glm::ivec3>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::ivec4> *>(input)) {
+        program->setUniform<glm::ivec4>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::uvec2> *>(input)) {
+        program->setUniform<glm::uvec2>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::uvec3> *>(input)) {
+        program->setUniform<glm::uvec3>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::uvec4> *>(input)) {
+        program->setUniform<glm::uvec4>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat2> *>(input)) {
+        program->setUniform<glm::mat2>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat3> *>(input)) {
+        program->setUniform<glm::mat3>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat4> *>(input)) {
+        program->setUniform<glm::mat4>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat2x3> *>(input)) {
+        program->setUniform<glm::mat2x3>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat3x2> *>(input)) {
+        program->setUniform<glm::mat3x2>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat2x4> *>(input)) {
+        program->setUniform<glm::mat2x4>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat4x2> *>(input)) {
+        program->setUniform<glm::mat4x2>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat3x4> *>(input)) {
+        program->setUniform<glm::mat3x4>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<glm::mat4x3> *>(input)) {
+        program->setUniform<glm::mat4x3>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<gl::GLuint64> *>(input)) {
+        program->setUniform<gl::GLuint64>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<globjects::TextureHandle> *>(input)) {
+        program->setUniform<globjects::TextureHandle>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<float>> *>(input)) {
+        program->setUniform<std::vector<float>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<int>> *>(input)) {
+        program->setUniform<std::vector<int>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<unsigned int>> *>(input)) {
+        program->setUniform<std::vector<unsigned int>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<bool>> *>(input)) {
+        program->setUniform<std::vector<bool>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::vec2>> *>(input)) {
+        program->setUniform<std::vector<glm::vec2>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::vec3>> *>(input)) {
+        program->setUniform<std::vector<glm::vec3>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::vec4>> *>(input)) {
+        program->setUniform<std::vector<glm::vec4>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::ivec2>> *>(input)) {
+        program->setUniform<std::vector<glm::ivec2>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::ivec3>> *>(input)) {
+        program->setUniform<std::vector<glm::ivec3>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::ivec4>> *>(input)) {
+        program->setUniform<std::vector<glm::ivec4>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::uvec2>> *>(input)) {
+        program->setUniform<std::vector<glm::uvec2>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::uvec3>> *>(input)) {
+        program->setUniform<std::vector<glm::uvec3>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::uvec4>> *>(input)) {
+        program->setUniform<std::vector<glm::uvec4>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat2>> *>(input)) {
+        program->setUniform<std::vector<glm::mat2>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat3>> *>(input)) {
+        program->setUniform<std::vector<glm::mat3>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat4>> *>(input)) {
+        program->setUniform<std::vector<glm::mat4>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat2x3>> *>(input)) {
+        program->setUniform<std::vector<glm::mat2x3>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat3x2>> *>(input)) {
+        program->setUniform<std::vector<glm::mat3x2>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat2x4>> *>(input)) {
+        program->setUniform<std::vector<glm::mat2x4>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat4x2>> *>(input)) {
+        program->setUniform<std::vector<glm::mat4x2>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat3x4>> *>(input)) {
+        program->setUniform<std::vector<glm::mat3x4>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<glm::mat4x3>> *>(input)) {
+        program->setUniform<std::vector<glm::mat4x3>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<gl::GLuint64>> *>(input)) {
+        program->setUniform<std::vector<gl::GLuint64>>(input->name(), typedInput->value());
+    } else if (auto * typedInput = dynamic_cast<Input<std::vector<globjects::TextureHandle>> *>(input)) {
+        program->setUniform<std::vector<globjects::TextureHandle>>(input->name(), typedInput->value());
     }
 }
 


### PR DESCRIPTION
This pull request contains a number of fixes or rather workarounds that were needed on my macos system to somehow repair rendering with gloperate. It seems that the type infos are somehow mixed up, and unfortunately it seems rather unpredictable what works in what situation.

A summary on what errors I encountered:

RenderPassStage(126):
    typeid check for Input<globjects::Texture *> fails, dynamic_cast works. Therefore I replaced all typeid checks with dynamic casts, which for some reason created errors in other parts (see below).

Stage.inl(41):
    dynamic_cast for Input<cppassist::FilePath> fails, typeid() works. For all other types, the dynamic cast seems to work. It seems that the typeinfo for this class is not exported properly, and it is the only case where we have a class from cppassist, the property specialization in cppexpose, and it is used in gloperate.

RenderInterface.cpp(59): (unsolved)
    For some reason, dynamic_cast for Output<DepthRenderTarget *> fails. However, dynamic_cast for Output<ColorRenderTarget *> works fine. I have no idea how to fix this.

I tried a number of things to fix the typeinfo problems in general, none of which made any difference:
- Use typeid.hash_code() for comparison
- Use CXX_VISIBILITY_PRESET="default" instead of "hidden"
- Use -fvisibility-ms-compat
- Load dynamic libraries with RTLD_GLOBAL and/or RTLD_NOW

I hope someone has an idea how to fix this properly, I'm currently out of ideas.