### PR TITLE
Various

### DIFF
--- a/data/gloperate/qml/InternalStage.qml
+++ b/data/gloperate/qml/InternalStage.qml
@@ -1,0 +1,76 @@
+
+import QtQuick 2.0
+
+
+/**
+*  InternalStage
+*
+*  Describes the state of an internal stage for (scripting and UI), only supports inputs
+*/
+Item
+{
+    id: stage
+
+    signal connectionCreated(string sourcePath, string sourceSlot, string destPath, string destSlot)
+    signal connectionRemoved(string path, string slot)
+
+    property string name:     '' ///< Name of the stage (for display)
+    property string path:     '' ///< Path of the stage
+    property var inputs:      [] ///< Input configuration of the stage
+    property var connections: {} ///< Connections to this stage
+
+    property bool isVisibleInternal: true ///< Whether this stage should be visible in 'internal' mode
+    property bool isVisibleExternal: true ///< Whether this stage should be visible in 'external' mode
+
+    function configureComponents(stageItem) {} ///< Configure stage item in pipeline editor
+
+    onConnectionCreated:
+    {
+        if (connections === undefined)
+        {
+            connections = {};
+        }
+        connections[destSlot] = sourcePath + '.' + sourceSlot;
+    }
+
+    onConnectionRemoved:
+    {
+        if (connections === undefined)
+        {
+            return;
+        }
+
+        delete connections[slot];
+    }
+
+    // Generate stage description with inputs, outputs, and stages
+    function getDescription() {
+        var inputNames = [];
+
+        for (var i in inputs)
+        {
+            var input = inputs[i];
+            inputNames.push(input.name);
+        }
+
+        return {
+            name:    path,
+            inputs:  inputNames,
+            outputs: [],
+            stages:  []
+        };
+    }
+
+    // Generate stage connections
+    function getConnections() {
+        var connectionList = [];
+
+        for (var slot in connections)
+        {
+            connectionList.push({from: connections[slot], to: path + '.' + slot});
+        }
+
+        return connectionList;
+    }
+
+}

--- a/data/gloperate/qml/InternalStage.qml
+++ b/data/gloperate/qml/InternalStage.qml
@@ -22,7 +22,20 @@ Item
     property bool isVisibleInternal: true ///< Whether this stage should be visible in 'internal' mode
     property bool isVisibleExternal: true ///< Whether this stage should be visible in 'external' mode
 
-    function configureComponents(stageItem) {} ///< Configure stage item in pipeline editor
+    property bool configured: false ///< Whether this stage is already configured
+
+    function onConfigure(stageItem) {} ///< To be overridden with actual configuration
+
+    function configure(stageItem) {
+        if (configured)
+        {
+            return;
+        }
+
+        onConfigure(stageItem);
+
+        configured = true;
+    }
 
     onConnectionCreated:
     {

--- a/data/gloperate/qml/PipelinePage.qml
+++ b/data/gloperate/qml/PipelinePage.qml
@@ -13,10 +13,10 @@ ScrollArea
     /// Called when a render stage has been selected
     signal renderStageSelected(string name)
 
-    property var categories:      []     ///< List of categories
-    property var stages:          {}     ///< List of stages, sorted by categories ( { 'cat1': [ { name: '', description: '', ... } ], 'cat2': [], ...})
-    property var currentCategory: 'Demo' ///< The currently selected category
-    property var currentStage:    ''     ///< The currently selected stage
+    property var categories:      []      ///< List of categories
+    property var stages:          {}      ///< List of stages, sorted by categories ( { 'cat1': [ { name: '', description: '', ... } ], 'cat2': [], ...})
+    property var currentCategory: 'Demos' ///< The currently selected category
+    property var currentStage:    ''      ///< The currently selected stage
 
     contentWidth:  layout.width
     contentHeight: layout.height
@@ -66,7 +66,7 @@ ScrollArea
 
                 Repeater
                 {
-                    model: item.stages[item.currentCategory].length
+                    model: item.stages === undefined ? 0 : item.stages[item.currentCategory].length
 
                     ClickLabel
                     {

--- a/data/gloperate/qml/PipelineView.qml
+++ b/data/gloperate/qml/PipelineView.qml
@@ -13,9 +13,11 @@ Item
     id: page
 
     signal closed()
+    signal toggled()
 
-    property var    properties: null ///< Interface for communicating with the actual properties
-    property string path:       ''   ///< Path to pipeline
+    property var    properties:   null ///< Interface for communicating with the actual properties
+    property string path:         ''   ///< Path to pipeline
+    property string toggleButton: ''   ///< Description of the toggle state button
 
     implicitWidth:  pipelineEditor.implicitWidth
     implicitHeight: pipelineEditor.implicitHeight
@@ -39,6 +41,21 @@ Item
             onClicked:
             {
                 page.closed();
+            }
+        }
+
+        Button
+        {
+            text: page.toggleButton
+            visible: page.toggleButton === "" ? false : true
+
+            anchors.top:     parent.top
+            anchors.right:   parent.right
+            anchors.margins: Ui.style.paddingMedium
+
+            onClicked:
+            {
+                page.toggled();
             }
         }
 
@@ -69,12 +86,9 @@ Item
         }
     }
 
-    onVisibleChanged:
+    function load()
     {
-        if (visible)
-        {
-            pipelineEditor.load(path);
-        }
+        pipelineEditor.load(path);
     }
 
     function update()

--- a/data/gloperate/qml/PipelineView.qml
+++ b/data/gloperate/qml/PipelineView.qml
@@ -69,24 +69,28 @@ Item
 
         pipelineEditor.load(path);
 
-        configureInternalStages(properties.getInternalStages());
+        configureInternalStages();
+
+        pipelineEditor.pipeline.stageCreated.connect(configureInternalStages);
     }
 
     function update()
     {
         pipelineEditor.update();
 
-        configureInternalStages(properties.getInternalStages());
+        configureInternalStages();
     }
 
-    function configureInternalStages(internalStages)
+    function configureInternalStages()
     {
+        var internalStages = properties.getInternalStages();
+
         for (var stageName in internalStages)
         {
             var stageDefinition = internalStages[stageName];
             var stageObject = pipelineEditor.pipeline.stageItems[stageDefinition.name];
 
-            stageDefinition.configureComponents(stageObject);
+            stageDefinition.configure(stageObject);
         }
     }
 }

--- a/data/gloperate/qml/PipelineView.qml
+++ b/data/gloperate/qml/PipelineView.qml
@@ -58,20 +58,30 @@ Item
                 page.toggled();
             }
         }
-
-        PreviewItem
-        {
-            path: 'ShapeDemo.Framebuffer.colorTexture'
-        }
     }
 
     function load()
     {
         pipelineEditor.load(path);
+
+        configureInternalStages(properties.getInternalStages());
     }
 
     function update()
     {
         pipelineEditor.update();
+
+        configureInternalStages(properties.getInternalStages());
+    }
+
+    function configureInternalStages(internalStages)
+    {
+        for (var stageName in internalStages)
+        {
+            var stageDefinition = internalStages[stageName];
+            var stageObject = pipelineEditor.pipeline.stageItems[stageDefinition.name];
+
+            stageDefinition.configureComponents(stageObject);
+        }
     }
 }

--- a/data/gloperate/qml/PipelineView.qml
+++ b/data/gloperate/qml/PipelineView.qml
@@ -59,30 +59,9 @@ Item
             }
         }
 
-        Rectangle
+        PreviewItem
         {
-            x:      100
-            y:      100
-            width:  200
-            height: 200
-
-            color:        'white'
-            border.color: 'black'
-            border.width: 1
-
-            TextureItem
-            {
-                anchors.fill: parent
-                anchors.margins: 1
-
-                path: 'ShapeDemo.Framebuffer.colorTexture'
-            }
-
-            MouseArea
-            {
-                anchors.fill: parent
-                drag.target: parent
-            }
+            path: 'ShapeDemo.Framebuffer.colorTexture'
         }
     }
 

--- a/data/gloperate/qml/PipelineView.qml
+++ b/data/gloperate/qml/PipelineView.qml
@@ -76,4 +76,9 @@ Item
             pipelineEditor.load(path);
         }
     }
+
+    function update()
+    {
+        pipelineEditor.update();
+    }
 }

--- a/data/gloperate/qml/PipelineView.qml
+++ b/data/gloperate/qml/PipelineView.qml
@@ -62,6 +62,11 @@ Item
 
     function load()
     {
+        if (pipelineEditor.loaded)
+        {
+            return;
+        }
+
         pipelineEditor.load(path);
 
         configureInternalStages(properties.getInternalStages());

--- a/data/gloperate/qml/PreviewItem.qml
+++ b/data/gloperate/qml/PreviewItem.qml
@@ -32,11 +32,5 @@ Item
 
             path: previewItem.path
         }
-
-        // MouseArea
-        // {
-        //     anchors.fill: parent
-        //     drag.target: parent
-        // }
     }
 }

--- a/data/gloperate/qml/PreviewItem.qml
+++ b/data/gloperate/qml/PreviewItem.qml
@@ -1,0 +1,43 @@
+
+import QtQuick 2.0
+import QtQuick.Layouts 1.1
+import QtQuick.Dialogs 1.0
+
+import QmlToolbox.Base 1.0
+import QmlToolbox.Controls 1.0
+
+import gloperate.rendering 1.0
+
+
+Item
+{
+    id: previewItem
+
+    property string path: '' ///< holds the path to the texture
+
+    Rectangle
+    {
+        x:      100
+        y:      100
+        width:  200
+        height: 200
+
+        color:        'white'
+        border.color: 'black'
+        border.width: 1
+
+        TextureItem
+        {
+            anchors.fill: parent
+            anchors.margins: 1
+
+            path: previewItem.path
+        }
+
+        MouseArea
+        {
+            anchors.fill: parent
+            drag.target: parent
+        }
+    }
+}

--- a/data/gloperate/qml/PreviewItem.qml
+++ b/data/gloperate/qml/PreviewItem.qml
@@ -1,10 +1,7 @@
 
 import QtQuick 2.0
-import QtQuick.Layouts 1.1
-import QtQuick.Dialogs 1.0
 
 import QmlToolbox.Base 1.0
-import QmlToolbox.Controls 1.0
 
 import gloperate.rendering 1.0
 
@@ -15,12 +12,14 @@ Item
 
     property string path: '' ///< holds the path to the texture
 
+    implicitWidth:  200
+    implicitHeight: 180
+
     Rectangle
     {
-        x:      100
-        y:      100
-        width:  200
-        height: 200
+        anchors.fill: parent
+        anchors.leftMargin: Ui.style.pipelineSlotSize
+        anchors.rightMargin: Ui.style.pipelineSlotSize / 2
 
         color:        'white'
         border.color: 'black'
@@ -34,10 +33,10 @@ Item
             path: previewItem.path
         }
 
-        MouseArea
-        {
-            anchors.fill: parent
-            drag.target: parent
-        }
+        // MouseArea
+        // {
+        //     anchors.fill: parent
+        //     drag.target: parent
+        // }
     }
 }

--- a/data/gloperate/qml/PreviewStage.qml
+++ b/data/gloperate/qml/PreviewStage.qml
@@ -45,7 +45,7 @@ Item
             previewComponent.path = '';
         }
 
-        function configureComponents(stageItem)
+        function onConfigure(stageItem)
         {
             previewComponent = stageItem.addComponent(newPreview, {});
         }

--- a/data/gloperate/qml/PreviewStage.qml
+++ b/data/gloperate/qml/PreviewStage.qml
@@ -1,0 +1,57 @@
+
+import QtQuick 2.0
+
+import gloperate.rendering 1.0
+
+
+/**
+*  PreviewStage
+*
+*  Describes the state of a preview stage
+*/
+Item
+{
+    id: previewStage
+
+    property var stageDefinition: internalStage ///< For access to stage definition
+
+    property var previewComponent: null ///< Preview component on stage item in pipeline editor
+
+    InternalStage
+    {
+        id: internalStage
+
+        name:    'PreviewStage'
+        path:    'root.PreviewStage'
+
+        inputs: [
+            {
+                name:  'PreviewTexture',
+                type:  'texture',
+                value: null,
+            }
+        ]
+
+        isVisibleInternal: true
+        isVisibleExternal: false
+
+        onConnectionCreated:
+        {
+            previewComponent.path = sourcePath + '.' + sourceSlot;
+        }
+
+        onConnectionRemoved:
+        {
+            previewComponent.path = '';
+        }
+
+        function configureComponents(stageItem)
+        {
+            previewComponent = stageItem.addComponent(newPreview, {});
+        }
+    }
+
+    property Component newPreview : PreviewItem
+    {
+    }
+}

--- a/data/gloperate/qml/SettingsPage.qml
+++ b/data/gloperate/qml/SettingsPage.qml
@@ -124,6 +124,26 @@ Item
 
                 Label
                 {
+                    Layout.alignment: Qt.AlignRight
+
+                    text: 'Pipeline Editor'
+                }
+
+                ComboBox
+                {
+                    model: [ 'external', 'internal' ]
+
+                    currentIndex: model.indexOf(settings.editor)
+
+                    onActivated:
+                    {
+                        var editor = model[index];
+                        settings.editor = editor;
+                    }
+                }
+
+                Label
+                {
                     Layout.alignment: Qt.AlignRight | Qt.AlignTop
 
                     text: 'Plugin Paths'

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -1,6 +1,7 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
+import QtQuick.Window 2.2
 
 import QmlToolbox.Base           1.0
 import QmlToolbox.Controls       1.0
@@ -163,8 +164,7 @@ ApplicationWindow
 
                         onTriggered:
                         {
-                            pipelineView.visible = true;
-                            mainView.visible     = false;
+                            showEditor();
                         }
                     }
                 }
@@ -247,7 +247,8 @@ ApplicationWindow
             settings.stage = name;
             window.stage   = name;
             propertyEditor.update();
-            pipelineView.update();
+            internalPipelineView.update();
+            externalPipelineView.update();
         }
     }
 
@@ -323,19 +324,88 @@ ApplicationWindow
         // Pipeline view
         PipelineView
         {
-            id: pipelineView
+            id: internalPipelineView
 
             anchors.fill: parent
             visible:      false
 
-            properties: gloperatePipeline
-            path:       'root'
+            properties:   gloperatePipeline
+            path:         'root'
+            toggleButton: 'Open in new window'
 
             onClosed:
             {
-                mainView.visible     = true;
-                pipelineView.visible = false;
+                hideEditor();
             }
+
+            onToggled:
+            {
+                toggleEditor();
+            }
+        }
+    }
+
+    // Pipeline view in separate window
+    Window
+    {
+        id: popoutWindow
+
+        title: 'Pipeline Editor'
+
+        PipelineView
+        {
+            id: externalPipelineView
+
+            anchors.fill: parent
+
+            properties:   gloperatePipeline
+            path:         'root'
+            toggleButton: 'Show inside main window'
+
+            onClosed:
+            {
+                hideEditor();
+            }
+
+            onToggled:
+            {
+                toggleEditor();
+            }
+        }
+    }
+
+    // Toggles between internal and external pipeline editor
+    function toggleEditor()
+    {
+        hideEditor();
+        settings.editor = (settings.editor === "internal" ? "external" : "internal");
+        showEditor();
+    }
+
+    // Shows the pipeline editor
+    function showEditor()
+    {
+        if (settings.editor === "internal")
+        {
+            internalPipelineView.visible = true;
+            mainView.visible             = false;
+            internalPipelineView.load();
+        } else {
+            popoutWindow.showMaximized();
+            popoutWindow.raise();
+            externalPipelineView.load();
+        }
+    }
+
+    // Hides the pipeline editor
+    function hideEditor()
+    {
+        if (settings.editor === "internal")
+        {
+            mainView.visible             = true;
+            internalPipelineView.visible = false;
+        } else {
+            popoutWindow.hide();
         }
     }
 
@@ -406,6 +476,7 @@ ApplicationWindow
         property int    logLevel:      3
         property bool   debugMode:     false
         property string panelPosition: 'left'
+        property string editor:        'internal'
         property string stage:         ''
         property string pluginPaths:   ''
 

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -403,13 +403,11 @@ ApplicationWindow
     // Hides the pipeline editor
     function hideEditor()
     {
-        if (settings.editor === "internal")
-        {
-            mainView.visible             = true;
-            internalPipelineView.visible = false;
-        } else {
-            popoutWindow.hide();
-        }
+        // hide internal editor
+        mainView.visible             = true;
+        internalPipelineView.visible = false;
+        // hide external editor
+        popoutWindow.hide();
     }
 
     // Bottom Panel

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -247,6 +247,7 @@ ApplicationWindow
             settings.stage = name;
             window.stage   = name;
             propertyEditor.update();
+            pipelineView.update();
         }
     }
 

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -526,6 +526,7 @@ ApplicationWindow
         // Add preview stage
         gloperatePipeline.clearInternalStages();
         gloperatePipeline.addInternalStage(previewStage.stageDefinition);
+        gloperatePipeline.editor = settings.editor;
 
         // Set render stage
         window.stage = settings.stage;

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -455,6 +455,8 @@ ApplicationWindow
     {
         id: gloperatePipeline
 
+        editor: settings.editor
+
         onCanvasChanged:
         {
             propertyEditor.update();
@@ -467,11 +469,6 @@ ApplicationWindow
                 });
             }
         }
-    }
-
-    PreviewStage
-    {
-        id: previewStage
     }
 
     Settings
@@ -526,10 +523,9 @@ ApplicationWindow
         // Scan for plugins
         gloperate.components.scanPlugins();
 
-        // Add preview stage
+        // Initialize internal stages and add one preview stage
         gloperatePipeline.clearInternalStages();
-        gloperatePipeline.addInternalStage(previewStage.stageDefinition);
-        gloperatePipeline.editor = settings.editor;
+        gloperatePipeline.createInternalStage("root", "PreviewStage", "PreviewStage");
 
         // Set render stage
         window.stage = settings.stage;

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -459,10 +459,13 @@ ApplicationWindow
         {
             propertyEditor.update();
 
-            canvas.onStageInputChanged(function(slot, status)
+            if (canvas)
             {
-                gloperatePipeline.slotChanged('root', slot, status);
-            });
+                canvas.onStageInputChanged(function(slot, status)
+                {
+                    gloperatePipeline.slotChanged('root', slot, status);
+                });
+            }
         }
     }
 

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -468,6 +468,11 @@ ApplicationWindow
         }
     }
 
+    PreviewStage
+    {
+        id: previewStage
+    }
+
     Settings
     {
         id: settings
@@ -499,6 +504,11 @@ ApplicationWindow
             gloperate.components.setPluginPaths(settings.pluginPaths);
             gloperate.components.scanPlugins();
         }
+
+        onEditorChanged:
+        {
+            gloperatePipeline.editor = settings.editor;
+        }
     }
 
     Component.onCompleted:
@@ -514,6 +524,10 @@ ApplicationWindow
 
         // Scan for plugins
         gloperate.components.scanPlugins();
+
+        // Add preview stage
+        gloperatePipeline.clearInternalStages();
+        gloperatePipeline.addInternalStage(previewStage.stageDefinition);
 
         // Set render stage
         window.stage = settings.stage;

--- a/data/gloperate/qml/Viewer.qml
+++ b/data/gloperate/qml/Viewer.qml
@@ -352,6 +352,9 @@ ApplicationWindow
 
         title: 'Pipeline Editor'
 
+        minimumWidth:  750
+        minimumHeight: 550
+
         PipelineView
         {
             id: externalPipelineView

--- a/source/gloperate-qtquick/source/TextureItemRenderer_ogl.cpp
+++ b/source/gloperate-qtquick/source/TextureItemRenderer_ogl.cpp
@@ -7,6 +7,8 @@
 
 #include <globjects/base/AbstractStringSource.h>
 #include <globjects/Framebuffer.h>
+#include <globjects/FramebufferAttachment.h>
+#include <globjects/AttachedTexture.h>
 #include <globjects/Texture.h>
 #include <globjects/Program.h>
 #include <globjects/Shader.h>
@@ -15,6 +17,7 @@
 #include <gloperate/base/Canvas.h>
 #include <gloperate/pipeline/Pipeline.h>
 #include <gloperate/rendering/ScreenAlignedQuad.h>
+#include <gloperate/rendering/ColorRenderTarget.h>
 
 #include <gloperate-qtquick/TextureItem.h>
 
@@ -77,6 +80,16 @@ void TextureItemRenderer::renderTexture()
     if (slot && slot->type() == typeid(globjects::Texture *))
     {
         texture = static_cast< Slot<globjects::Texture *> * >(slot)->value();
+    }
+
+    // Check if it is a texture slot
+    if (slot && slot->type() == typeid(gloperate::ColorRenderTarget *))
+    {
+        gloperate::ColorRenderTarget * renderTarget = static_cast< Slot<gloperate::ColorRenderTarget *> * >(slot)->value();
+        if (renderTarget->currentTargetType() == RenderTargetType::UserDefinedFBOAttachment)
+        {
+            texture = renderTarget->framebufferAttachment()->asTextureAttachment()->texture();
+        }
     }
 
     // Abort if texture is invalid

--- a/source/gloperate-qtquick/source/TextureItemRenderer_ogl.cpp
+++ b/source/gloperate-qtquick/source/TextureItemRenderer_ogl.cpp
@@ -62,7 +62,15 @@ void TextureItemRenderer::renderTexture()
     Canvas * canvas = m_environment->canvases().front();
     Stage * stage = canvas->renderStage();
     if (!stage) return;
-    AbstractSlot * slot = stage->getSlot(m_path.toStdString());
+
+    std::string slotPath = m_path.toStdString();
+
+    // Replace root in slot path with render stage name
+    if (string::hasPrefix(slotPath, "root")) {
+        slotPath.replace(0, 4, stage->name());
+    }
+
+    AbstractSlot * slot = stage->getSlot(slotPath);
     if (!slot) return;
 
     // Check if it is a texture slot

--- a/source/gloperate/source/base/Canvas.cpp
+++ b/source/gloperate/source/base/Canvas.cpp
@@ -862,6 +862,7 @@ cppexpose::Variant Canvas::getSlotStatus(const std::string & path, const std::st
             (*status.asMap())["name"]  = slot->name();
             (*status.asMap())["type"]  = slot->typeName();
             (*status.asMap())["value"] = slot->toVariant();
+            (*status.asMap())["required"] = slot->isRequired();
 
             // Include options
             const VariantMap & options = slot->options();

--- a/source/gloperate/source/base/Canvas.cpp
+++ b/source/gloperate/source/base/Canvas.cpp
@@ -656,6 +656,11 @@ cppexpose::Variant Canvas::scr_getConnections(const std::string & path)
                 (*connection.asMap())["from"] = from;
                 (*connection.asMap())["to"]   = to;
 
+                if (slot->isFeedback())
+                {
+                    (*connection.asMap())["feedback"] = true;
+                }
+
                 // Add connection
                 obj.asArray()->push_back(connection);
             }


### PR DESCRIPTION
This PR depends on cginternals/qmltoolbox#31.

- Introduces internal stages (stages existing only in the UI, not in the actual pipeline)
- The former preview item was converted to an internal PreviewStage
- The preview item currently can be connected to slots of type `globjects::texture` and `gloperate::ColorRenderTarget` with type `UserDefinedFBOAttachment`
- Added: information on required slots and feedback connections
- Fixed: changing the pipeline through the UI also updates the editor correctly 

Bugged:

- Preview stages have wrong dimensions/data in the new "external" window mode, however this would often be used with a second display, and the preview stages might not be needed in that case anyway, therefore they are currently hidden in "external" mode

Missing:

- It would be nice to automatically connect the (first) PreviewStage to the same output which is connected to the `ColorOut` slot of the a pipeline.
- Support other RenderTargets and types of render targets