### PR TITLE
Enable simple time measurements for stages

### DIFF
--- a/source/gloperate/include/gloperate/pipeline/Stage.h
+++ b/source/gloperate/include/gloperate/pipeline/Stage.h
@@ -57,7 +57,7 @@ public:
 
     template <typename T>
     using Output = gloperate::Output<T>;
-    
+
     // Helper class for createInput()
     class GLOPERATE_API CreateConnectedInputProxy
     {
@@ -83,11 +83,12 @@ public:
 
 
 public:
-    cppexpose::Signal<AbstractSlot *> inputAdded;    ///< Called when an input slot has been added
-    cppexpose::Signal<AbstractSlot *> inputRemoved;  ///< Called when an input slot has been removed
-    cppexpose::Signal<AbstractSlot *> outputAdded;   ///< Called when an output slot has been added
-    cppexpose::Signal<AbstractSlot *> outputRemoved; ///< Called when an output slot has been removed
-    cppexpose::Signal<AbstractSlot *> inputChanged;  ///< Called when an input slot has changed its value or options
+    cppexpose::Signal<AbstractSlot *>     inputAdded;    ///< Called when an input slot has been added
+    cppexpose::Signal<AbstractSlot *>     inputRemoved;  ///< Called when an input slot has been removed
+    cppexpose::Signal<AbstractSlot *>     outputAdded;   ///< Called when an output slot has been added
+    cppexpose::Signal<AbstractSlot *>     outputRemoved; ///< Called when an output slot has been removed
+    cppexpose::Signal<AbstractSlot *>     inputChanged;  ///< Called when an input slot has changed its value or options
+    cppexpose::Signal<uint64_t, uint64_t> timeMeasured;  ///< Called when the timing has been measured
 
 
 public:
@@ -380,7 +381,7 @@ public:
     *
     *  @remarks
     *    The operator<< must be called exactly once on the returned proxy object.
-    *    
+    *
     *    createInput("somename") << someOutput; behaves exactly like
     *    createConnectedInput("somename", someOutput);
     */
@@ -652,6 +653,53 @@ public:
     template <typename T>
     void forAllOutputs(std::function<void(gloperate::Output<T> *)> callback);
 
+    /**
+    *  @brief
+    *    Get CPU duration of onProcess in nanoseconds.
+    *
+    *  @return
+    *    duration in nanoseconds
+    *
+    *  @remarks
+    *    To be consistent with 'lastGPUTime', this value is one iteration (i.e. frame) late.
+    */
+    std::uint64_t lastCPUTime() const;
+
+    /**
+    *  @brief
+    *    Get GPU time for GPU commands issued during onProcess in nanoseconds.
+    *
+    *  @return
+    *    duration in nanoseconds
+    *
+    *  @remarks
+    *    Due to the async nature of GPU processing, this value is one iteration (i.e. frame) late.
+    */
+    std::uint64_t lastGPUTime() const;
+
+    /**
+    *  @brief
+    *    Check if time measurements are enabled
+    *
+    *  @return
+    *    'true' if time measurements are enabled, else 'false'
+    */
+    bool timeMeasurement() const;
+
+    /**
+    *  @brief
+    *    Enable or disable time measurement
+    *
+    *  @param[in] enabled
+    *    'true' if enabled, 'false' if disabled
+    *  @param[in] recursive
+    *    If 'true', time measurements are set recursively on all substages
+    *
+    *  @remarks
+    *    Previous measurement values are set to 0.
+    */
+    virtual void setTimeMeasurement(bool enabled, bool recursive = false);
+
 
 protected:
     /**
@@ -782,6 +830,13 @@ protected:
 protected:
     Environment * m_environment;    ///< Gloperate environment to which the stage belongs
     bool          m_alwaysProcess;  ///< Is the stage always processed?
+
+    bool                        m_useQueryPairOne;      ///< internal counter to access ring buffers
+    std::array<unsigned int, 4> m_queries;              ///< Query openGL objects (front/back; start/end)
+    bool                        m_timeMeasurement;      ///< Status of time measurements for CPU and GPU
+    uint64_t                    m_lastCPUDuration;      ///< nanoseconds spend in onProcess last frame
+    uint64_t                    m_currentCPUDuration;   ///< nanoseconds spend in onProcess current frame
+    uint64_t                    m_lastGPUDuration;      ///< nanoseconds for GPU commands issued during onProcess
 
     std::vector<AbstractSlot *>                     m_inputs;     ///< List of inputs
     std::unordered_map<std::string, AbstractSlot *> m_inputsMap;  ///< Map of names and inputs

--- a/source/gloperate/include/gloperate/pipeline/Stage.h
+++ b/source/gloperate/include/gloperate/pipeline/Stage.h
@@ -831,12 +831,13 @@ protected:
     Environment * m_environment;    ///< Gloperate environment to which the stage belongs
     bool          m_alwaysProcess;  ///< Is the stage always processed?
 
-    bool                        m_useQueryPairOne;      ///< internal counter to access ring buffers
-    std::array<unsigned int, 4> m_queries;              ///< Query openGL objects (front/back; start/end)
     bool                        m_timeMeasurement;      ///< Status of time measurements for CPU and GPU
-    uint64_t                    m_lastCPUDuration;      ///< nanoseconds spend in onProcess last frame
-    uint64_t                    m_currentCPUDuration;   ///< nanoseconds spend in onProcess current frame
-    uint64_t                    m_lastGPUDuration;      ///< nanoseconds for GPU commands issued during onProcess
+    bool                        m_useQueryPairOne;      ///< Flag indicating which queries are currently used
+    bool                        m_resultAvailable;      ///< Flag indicating whether a measurement from previous frames is available for report
+    std::array<unsigned int, 4> m_queries;              ///< OpenGL query objects (front/back; start/end)
+    uint64_t                    m_lastCPUDuration;      ///< Time spent in onProcess last frame (in nanoseconds)
+    uint64_t                    m_currentCPUDuration;   ///< Time spent in onProcess current frame (in nanoseconds)
+    uint64_t                    m_lastGPUDuration;      ///< Time for GPU commands issued during onProcess (in nanoseconds)
 
     std::vector<AbstractSlot *>                     m_inputs;     ///< List of inputs
     std::unordered_map<std::string, AbstractSlot *> m_inputsMap;  ///< Map of names and inputs

--- a/source/gloperate/source/pipeline/Stage.cpp
+++ b/source/gloperate/source/pipeline/Stage.cpp
@@ -8,6 +8,8 @@
 
 #include <cppexpose/variant/Variant.h>
 
+#include <glbinding/gl/gl.h>
+
 #include <globjects/Texture.h>
 #include <globjects/Framebuffer.h>
 
@@ -18,6 +20,18 @@
 
 using namespace cppassist;
 using namespace cppexpose;
+
+
+namespace
+{
+    enum Query
+    {
+        PairOneStart = 0,
+        PairOneEnd = 1,
+        PairTwoStart = 2,
+        PairTwoEnd = 3
+    };
+}
 
 
 namespace gloperate
@@ -40,6 +54,11 @@ Stage::Stage(Environment * environment, const std::string & className, const std
 : cppexpose::Object((name.empty()) ? className : name)
 , m_environment(environment)
 , m_alwaysProcess(false)
+, m_useQueryPairOne(true)
+, m_timeMeasurement(false)
+, m_lastCPUDuration(0)
+, m_currentCPUDuration(0)
+, m_lastGPUDuration(0)
 {
     // Set object class name
     setClassName(className);
@@ -90,6 +109,20 @@ bool Stage::requires(const Stage * stage, bool recursive) const
 void Stage::initContext(AbstractGLContext * context)
 {
     debug(2, "gloperate") << this->qualifiedName() << ": initContext";
+
+    gl::glGenQueries(4, m_queries.data());
+    // dummy querys for first frame
+    if (m_useQueryPairOne)
+    {
+        gl::glQueryCounter(m_queries[Query::PairOneStart], gl::GL_TIMESTAMP);
+        gl::glQueryCounter(m_queries[Query::PairOneEnd], gl::GL_TIMESTAMP);
+    }
+    else
+    {
+        gl::glQueryCounter(m_queries[Query::PairTwoStart], gl::GL_TIMESTAMP);
+        gl::glQueryCounter(m_queries[Query::PairTwoEnd], gl::GL_TIMESTAMP);
+    }
+
     onContextInit(context);
 }
 
@@ -102,7 +135,47 @@ void Stage::deinitContext(AbstractGLContext * context)
 void Stage::process()
 {
     debug(1, "gloperate") << this->qualifiedName() << ": processing";
-    onProcess();
+
+    if (m_timeMeasurement)
+    {
+        auto usedStartQuery = m_useQueryPairOne ? Query::PairOneStart : Query::PairTwoStart;
+        auto usedEndQuery = m_useQueryPairOne ? Query::PairOneEnd : Query::PairTwoEnd;
+        auto unusedStartQuery = m_useQueryPairOne ? Query::PairTwoStart : Query::PairOneStart;
+        auto unusedEndQuery = m_useQueryPairOne ? Query::PairTwoEnd : Query::PairOneEnd;
+
+        // Start CPU time measurement
+        auto cpu_start = std::chrono::high_resolution_clock::now();
+
+        // Start GPU time measurement
+        gl::glQueryCounter(m_queries[unusedStartQuery], gl::GL_TIMESTAMP);
+
+        // Execute stage
+        onProcess();
+
+        // Stop CPU time measurement
+        auto cpu_end = std::chrono::high_resolution_clock::now();
+        m_lastCPUDuration = m_currentCPUDuration;
+        m_currentCPUDuration = std::chrono::duration_cast<std::chrono::nanoseconds>(cpu_end - cpu_start).count();
+
+        // Stop GPU time measurement
+        gl::glQueryCounter(m_queries[unusedEndQuery], gl::GL_TIMESTAMP);
+
+        // Get GPU values from last frame
+        gl::GLuint64 gpu_start, gpu_end;
+        gl::glGetQueryObjectui64v(m_queries[usedStartQuery], gl::GL_QUERY_RESULT, &gpu_start);
+        gl::glGetQueryObjectui64v(m_queries[usedEndQuery], gl::GL_QUERY_RESULT, &gpu_end);
+        m_lastGPUDuration = gpu_end - gpu_start;
+
+        // Switch queries for next frame
+        m_useQueryPairOne = !m_useQueryPairOne;
+
+        // Emit measured times
+        timeMeasured(m_currentCPUDuration, m_lastGPUDuration);
+    }
+    else
+    {
+        onProcess();
+    }
 
     for (auto input : m_inputs)
     {
@@ -528,6 +601,29 @@ void Stage::forAllOutputs(std::function<void(gloperate::AbstractSlot *)> callbac
     {
         callback(output);
     }
+}
+
+std::uint64_t Stage::lastCPUTime() const
+{
+    return m_lastCPUDuration;
+}
+
+std::uint64_t Stage::lastGPUTime() const
+{
+    return m_lastGPUDuration;
+}
+
+bool Stage::timeMeasurement() const
+{
+    return m_timeMeasurement;
+}
+
+void Stage::setTimeMeasurement(bool enabled, bool)
+{
+    m_currentCPUDuration = 0;
+    m_lastCPUDuration    = 0;
+    m_lastGPUDuration    = 0;
+    m_timeMeasurement    = enabled;
 }
 
 


### PR DESCRIPTION
This enables time measurements on stages. Based on the alternative_measurement branch, but without the overall framework for catching the timings in the canvas etc. Instead adds a signal to the stage to individually catch timing values of stages.