### PR TITLE
Promote mouse-move events in qtquick also when mouse button is not down

### DIFF
--- a/source/gloperate-qtquick/include/gloperate-qtquick/RenderItem.h
+++ b/source/gloperate-qtquick/include/gloperate-qtquick/RenderItem.h
@@ -92,6 +92,7 @@ public:
 protected:
     virtual void keyPressEvent(QKeyEvent * event) override;
     virtual void keyReleaseEvent(QKeyEvent * event) override;
+    virtual void hoverMoveEvent(QHoverEvent * event) override;
     virtual void mouseMoveEvent(QMouseEvent * event) override;
     virtual void mousePressEvent(QMouseEvent * event) override;
     virtual void mouseReleaseEvent(QMouseEvent * event) override;

--- a/source/gloperate-qtquick/source/RenderItem.cpp
+++ b/source/gloperate-qtquick/source/RenderItem.cpp
@@ -33,6 +33,7 @@ RenderItem::RenderItem(QQuickItem * parent)
 {
     // Set input modes
     setAcceptedMouseButtons(Qt::AllButtons);
+    setAcceptHoverEvents(true);
     setFlag(ItemAcceptsInputMethod, true);
 
     // Connect update timer
@@ -145,6 +146,17 @@ void RenderItem::mouseMoveEvent(QMouseEvent * event)
     }
 }
 
+void RenderItem::hoverMoveEvent(QHoverEvent * event)
+{
+    if (m_canvas)
+    {
+        m_canvas->promoteMouseMove(glm::ivec2(
+            (int)(event->pos().x() * window()->devicePixelRatio()),
+            (int)(event->pos().y() * window()->devicePixelRatio()))
+        );
+    }
+}
+
 void RenderItem::mousePressEvent(QMouseEvent * event)
 {
     if (m_canvas)
@@ -182,7 +194,7 @@ void RenderItem::wheelEvent(QWheelEvent * event)
     }
 }
 
-void RenderItem::onTimer()    
+void RenderItem::onTimer()
 {
     if (m_canvas)
     {


### PR DESCRIPTION
Before, mouse move events were only generating when a mouse button was hold down. Since our currently implemented camera navigation only uses it this way, the problem didn't show.