### PR TITLE
Fix stage sorting crashing when detecting loop

### DIFF
--- a/source/gloperate/source/pipeline/Pipeline.cpp
+++ b/source/gloperate/source/pipeline/Pipeline.cpp
@@ -173,7 +173,6 @@ void Pipeline::sortStages()
         {
             critical() << "Pipeline is not a directed acyclic graph";
             couldBeSorted = false;
-            addSorted(stage);
             return;
         }
 


### PR DESCRIPTION
Avoid handling the stage closing the loop twice