### PR TITLE
Camera review

### DIFF
--- a/source/examples/demo-stages-plugins/MultiFrameRenderingPipeline.cpp
+++ b/source/examples/demo-stages-plugins/MultiFrameRenderingPipeline.cpp
@@ -59,9 +59,10 @@ MultiFrameRenderingPipeline::MultiFrameRenderingPipeline(gloperate::Environment 
 , m_postprocessingPassStage(cppassist::make_unique<gloperate::RenderPassStage>(environment, "PostprocessingPassStage"))
 , m_postprocessingClearStage(cppassist::make_unique<gloperate::ClearStage>(environment, "PostprocessingClearStage"))
 , m_postprocessingRasterizationStage(cppassist::make_unique<gloperate::RasterizationStage>(environment, "PostprocessingRasterizationStage"))
-, m_camera(cppassist::make_unique<gloperate::Camera>(glm::vec3(2.0f, 1.0f, 1.0f), glm::vec3(0.0f), glm::vec3(0.0f, 1.0f, 0.0f)))
+, m_camera(cppassist::make_unique<gloperate::Camera>())
 {
     camera = m_camera.get();
+    camera->lookAt(glm::vec3(2.0f, 1.0f, 1.0f), glm::vec3(0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
 
     auto dataPath = gloperate::dataPath();
 

--- a/source/gloperate/include/gloperate/rendering/Camera.h
+++ b/source/gloperate/include/gloperate/rendering/Camera.h
@@ -15,15 +15,13 @@ namespace gloperate
 
 /**
 *  @brief
-*    Represents matrices for a typical 3D perspective look-at camera.
+*    Represents matrices for a camera within a virtual scene.
 *
-*    A camera is specified via near, far, fovy, as well as an eye, a center, and an up 
-*    vector. Camera itself does not use any OpenGL calls, but merely provides lazy
-*    math to all common matrices required for affine transformation of a scene,
-*    namely the view and projection matrices, their combination and all related
-*    inverses (as well as a normal matrix).
-*    The class relies on lazy computation of all matrices, causing less recomputations
-*    of, e.g., matrices and inverse matrices requested on an irregular basis.
+*    The camera provides access to view and projection matrices that can be configured
+*    as well as accessors for derived inverted matrices, their products and a
+*    normal matrix.
+*
+*    For convenience, setters that wrap glm camera functions are provided.
 */
 class GLOPERATE_API Camera
 {
@@ -35,184 +33,14 @@ public:
     /**
     *  @brief
     *    Constructor
-    *
-    *  @param[in] eye
-    *    Camera position
-    *  @param[in] center
-    *    Look-at position
-    *  @param[in] up
-    *    Up-vector
     */
-    Camera(const glm::vec3 & eye    = glm::vec3(0.0, 0.0, 1.0),
-           const glm::vec3 & center = glm::vec3(0.0, 0.0, 0.0),
-           const glm::vec3 & up     = glm::vec3(0.0, 1.0, 0.0) );
+    Camera();
 
     /**
     *  @brief
     *    Destructor
     */
     virtual ~Camera();
-
-    /**
-    *  @brief
-    *    Check if camera is updated automatically
-    *
-    *  @return
-    *    'true' if camera is updated automatically, else 'false'
-    */
-    bool autoUpdating() const;
-
-    /**
-    *  @brief
-    *    Set if camera is updated automatically
-    *
-    *  @param[in] autoUpdate
-    *    'true' if camera is updated automatically, else 'false'
-    */
-    void setAutoUpdating(bool autoUpdate);
-
-    /**
-    *  @brief
-    *    Update camera matrices
-    */
-    void update() const;
-
-    /**
-    *  @brief
-    *    Get camera (eye) position
-    *
-    *  @return
-    *    Camera position
-    */
-    const glm::vec3 & eye() const;
-
-    /**
-    *  @brief
-    *    Set camera (eye) position
-    *
-    *  @param[in] eye
-    *    Camera position
-    */
-    void setEye(const glm::vec3 & eye);
-
-    /**
-    *  @brief
-    *    Get look-at (center) position
-    *
-    *  @return
-    *    Look-at position
-    */
-    const glm::vec3 & center() const;
-
-    /**
-    *  @brief
-    *    Set look-at (center) position
-    *
-    *  @param[in] center
-    *    Look-at position
-    */
-    void setCenter(const glm::vec3 & center);
-
-    /**
-    *  @brief
-    *    Get up-vector
-    *
-    *  @return
-    *    Up-vector
-    */
-    const glm::vec3 & up() const;
-
-    /**
-    *  @brief
-    *    Set up-vector
-    *
-    *  @param[in] up
-    *    Up-vector
-    */
-    void setUp(const glm::vec3 & up);
-
-    /**
-    *  @brief
-    *    Get near plane
-    *
-    *  @return
-    *    Near plane
-    */
-    float zNear() const;
-
-    /**
-    *  @brief
-    *    Set near plane
-    *
-    *  @param[in] zNear
-    *    Near plane
-    */
-    void setZNear(float zNear);
-
-    /**
-    *  @brief
-    *    Get far plane
-    *
-    *  @return
-    *    Far plane
-    */
-    float zFar() const;
-
-    /**
-    *  @brief
-    *    Set far plane
-    *
-    *  @param[in] zFar
-    *    Far plane
-    */
-    void setZFar(float zFar);
-
-    /**
-    *  @brief
-    *    Get field-of-view angle (Y)
-    *
-    *  @return
-    *    Angle
-    */
-    float fovy() const;
-
-    /**
-    *  @brief
-    *    Set field-of-view angle (Y)
-    *
-    *  @param[in] fovy
-    *    Angle
-    */
-    void setFovy(float fovy);
-
-    /**
-    *  @brief
-    *    Get aspect ratio (width / height)
-    *
-    *  @return
-    *    Aspect ratio
-    */
-    float aspectRatio() const;
-
-    /**
-    *  @brief
-    *    Set aspect ratio (width / height)
-    *
-    *  @param[in] ratio
-    *    Aspect ratio
-    */
-    void setAspectRatio(float ratio);
-
-    /**
-    *  @brief
-    *    Set aspect ratio by providing a viewport
-    *
-    *  @param[in] viewport
-    *    Viewport size
-    */
-    void setAspectRatio(const glm::ivec2 & viewport);
-
-    // lazy matrices getters
 
     /**
     *  @brief
@@ -279,12 +107,70 @@ public:
 
     /**
     *  @brief
+    *    Set a look-at view matrix
+    *
+    *  @param[in] eye
+    *    Camera position
+    *  @param[in] center
+    *    Look-at position
+    *  @return
+    *    Up-vector
+    */
+    void lookAt(const glm::vec3 & eye, const glm::vec3 & center, const glm::vec3 & up);
+
+    /**
+    *  @brief
+    *    Set a perspective projection matrix
+    *
+    *  @param[in] fovy
+    *    Vertical angle
+    *  @param[in] ratio
+    *    Aspect ratio
+    *  @param[in] zNear
+    *    Near plane
+    *  @param[in] zFar
+    *    Far plane
+    */
+    void perspective(float fovy, float ratio, float zNear, float zFar);
+
+    /**
+    *  @brief
+    *    Set a perspective projection matrix
+    *
+    *  @param[in] fovy
+    *    Vertical angle
+    *  @param[in] viewport
+    *    Target viewport, used to derive the aspect ratio
+    *  @param[in] zNear
+    *    Near plane
+    *  @param[in] zFar
+    *    Far plane
+    */
+    void perspective(float fovy, const glm::ivec2 & viewport, float zNear, float zFar);
+
+    /**
+    *  @brief
+    *    Recompute eye from view matrix
+    *
+    *  @return
+    *    The position of the camera in world space
+    */
+    glm::vec3 eyeFromViewMatrix() const;
+
+
+protected:
+    /**
+    *  @brief
+    *    Update camera matrices
+    */
+    void update() const;
+
+    /**
+    *  @brief
     *    Emit signal that camera has been modified
     */
     void changed();
 
-
-protected:
     /**
     *  @brief
     *    Mark data dirty
@@ -305,23 +191,10 @@ protected:
 
 
 protected:
-    // Internal data
-    mutable bool m_dirty; ///< Has the data been changed? If true, matrices will be recalculated
-    bool m_autoUpdate;    ///< 'true' if camera is updated automatically, else 'false'
-
-    // Camera data
-    glm::vec3 m_eye;      ///< Camera position
-    glm::vec3 m_center;   ///< Look-at position
-    glm::vec3 m_up;       ///< Up-vector
-    float     m_fovy;     ///< Field-of-view angle (Y)
-    float     m_aspect;   ///< Aspect ratio (width / height)
-    float     m_zNear;    ///< Near plane
-    float     m_zFar;     ///< Far plane
-
     // Camera matrices
-    gloperate::CachedValue<glm::mat4> m_viewMatrix;                   ///< View matrix
+                           glm::mat4  m_viewMatrix;                   ///< View matrix
+                           glm::mat4  m_projectionMatrix;             ///< Projection matrix
     gloperate::CachedValue<glm::mat4> m_viewInvertedMatrix;           ///< Inverted view matrix
-    gloperate::CachedValue<glm::mat4> m_projectionMatrix;             ///< Projection matrix
     gloperate::CachedValue<glm::mat4> m_projectionInvertedMatrix;     ///< Inverted projection matrix
     gloperate::CachedValue<glm::mat4> m_viewProjectionMatrix;         ///< View-projection matrix
     gloperate::CachedValue<glm::mat4> m_viewProjectionInvertedMatrix; ///< Invertex view-projection matrix

--- a/source/gloperate/include/gloperate/rendering/Camera.h
+++ b/source/gloperate/include/gloperate/rendering/Camera.h
@@ -53,12 +53,30 @@ public:
 
     /**
     *  @brief
+    *    Set view matrix
+    *
+    *  @param[in] matrix
+    *    View matrix
+    */
+    void setViewMatrix(const glm::mat4 & matrix);
+
+    /**
+    *  @brief
     *    Get projection matrix
     *
     *  @return
     *    Projection matrix
     */
     const glm::mat4 & projectionMatrix() const;
+
+    /**
+    *  @brief
+    *    Set projection matrix
+    *
+    *  @param[in] matrix
+    *    Projection matrix
+    */
+    void setProjectionMatrix(const glm::mat4 & matrix);
 
     /**
     *  @brief
@@ -147,6 +165,40 @@ public:
     *    Far plane
     */
     void perspective(float fovy, const glm::ivec2 & viewport, float zNear, float zFar);
+
+    /**
+    *  @brief
+    *    Set a orthogonal projection matrix
+    *
+    *  @param[in] left
+    *    Left border of viewbox
+    *  @param[in] right
+    *    Right border of viewbox
+    *  @param[in] top
+    *    Top border of viewbox
+    *  @param[in] bottom
+    *    Bottom border of viewbox
+    *  @param[in] zNear
+    *    Near plane
+    *  @param[in] zFar
+    *    Far plane
+    */
+    void ortho(float left, float right, float top, float bottom, float zNear, float zFar);
+
+    /**
+    *  @brief
+    *    Set a orthogonal projection matrix
+    *
+    *  @param[in] fovy
+    *    Vertical angle
+    *  @param[in] ratio
+    *    Aspect ratio
+    *  @param[in] zNear
+    *    Near plane
+    *  @param[in] zFar
+    *    Far plane
+    */
+    void ortho(float fovy, float aspect, float zNear, float zFar);
 
     /**
     *  @brief

--- a/source/gloperate/include/gloperate/rendering/Camera.h
+++ b/source/gloperate/include/gloperate/rendering/Camera.h
@@ -183,7 +183,7 @@ public:
     *  @param[in] zFar
     *    Far plane
     */
-    void ortho(float left, float right, float top, float bottom, float zNear, float zFar);
+    void ortho(float left, float right, float bottom, float top, float zNear, float zFar);
 
     /**
     *  @brief

--- a/source/gloperate/source/gloperate.cpp
+++ b/source/gloperate/source/gloperate.cpp
@@ -3,8 +3,6 @@
 
 #include <cppassist/fs/FilePath.h>
 
-#include <iostream>
-
 #include <cpplocate/cpplocate.h>
 
 
@@ -45,8 +43,6 @@ const std::string & dataPath()
 const std::string & pluginPath()
 {
     static const auto path = determinePluginPath();
-
-    std::cout << "Plugin path: " << path << std::endl;
 
     return path;
 }

--- a/source/gloperate/source/gloperate.cpp
+++ b/source/gloperate/source/gloperate.cpp
@@ -3,6 +3,8 @@
 
 #include <cppassist/fs/FilePath.h>
 
+#include <iostream>
+
 #include <cpplocate/cpplocate.h>
 
 
@@ -43,6 +45,8 @@ const std::string & dataPath()
 const std::string & pluginPath()
 {
     static const auto path = determinePluginPath();
+
+    std::cout << "Plugin path: " << path << std::endl;
 
     return path;
 }

--- a/source/gloperate/source/rendering/Camera.cpp
+++ b/source/gloperate/source/rendering/Camera.cpp
@@ -25,21 +25,27 @@ Camera::~Camera()
 
 void Camera::lookAt(const glm::vec3 & eye, const glm::vec3 & center, const glm::vec3 & up)
 {
-    m_viewMatrix = glm::lookAt(eye, center, up);
-
-    update();
+    setViewMatrix(glm::lookAt(eye, center, up));
 }
 
 void Camera::perspective(float fovy, float ratio, float zNear, float zFar)
 {
-    m_projectionMatrix = glm::perspective(fovy, ratio, zNear, zFar);
-
-    update();
+    setProjectionMatrix(glm::perspective(fovy, ratio, zNear, zFar));
 }
 
 void Camera::perspective(float fovy, const ivec2 &viewport, float zNear, float zFar)
 {
-    perspective(fovy, glm::max(float(viewport.x) / viewport.y, 1.0f), zNear, zFar);
+    setProjectionMatrix(glm::perspective(fovy, glm::max(float(viewport.x) / viewport.y, 1.0f), zNear, zFar));
+}
+
+void Camera::ortho(float left, float right, float top, float bottom, float zNear, float zFar)
+{
+    setProjectionMatrix(glm::ortho(left, right, bottom, bottom, zNear, zFar));
+}
+
+void Camera::ortho(float fovy, float aspect, float zNear, float zFar)
+{
+    setProjectionMatrix(glm::ortho(-fovy * aspect, fovy * aspect, -fovy, fovy, zNear, zFar));
 }
 
 void Camera::update() const
@@ -54,9 +60,23 @@ const mat4 & Camera::viewMatrix() const
     return m_viewMatrix;
 }
 
+void Camera::setViewMatrix(const glm::mat4 & matrix)
+{
+    m_viewMatrix = matrix;
+
+    update();
+}
+
 const mat4 & Camera::projectionMatrix() const
 {
     return m_projectionMatrix;
+}
+
+void Camera::setProjectionMatrix(const glm::mat4 & matrix)
+{
+    m_projectionMatrix = matrix;
+
+    update();
 }
 
 const mat4 & Camera::viewProjectionMatrix() const

--- a/source/gloperate/source/rendering/Camera.cpp
+++ b/source/gloperate/source/rendering/Camera.cpp
@@ -1,6 +1,7 @@
 
 #include <gloperate/rendering/Camera.h>
 
+#include <glm/common.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/matrix_inverse.hpp>
 
@@ -12,16 +13,9 @@ namespace gloperate
 {
 
 
-Camera::Camera(const vec3 & eye, const vec3 & center, const vec3 & up)
-: m_dirty(false)
-, m_autoUpdate(false)
-, m_eye(eye)
-, m_center(center)
-, m_up(up)
-, m_fovy(radians(40.f))
-, m_aspect(1.f)
-, m_zNear(0.1f)
-, m_zFar(64.0f)
+Camera::Camera()
+: m_viewMatrix(1.0f)
+, m_projectionMatrix(1.0f)
 {
 }
 
@@ -29,169 +23,44 @@ Camera::~Camera()
 {
 }
 
-bool Camera::autoUpdating() const
+void Camera::lookAt(const glm::vec3 & eye, const glm::vec3 & center, const glm::vec3 & up)
 {
-    return m_autoUpdate;
+    m_viewMatrix = glm::lookAt(eye, center, up);
+
+    update();
 }
 
-void Camera::setAutoUpdating(bool autoUpdate)
+void Camera::perspective(float fovy, float ratio, float zNear, float zFar)
 {
-    m_autoUpdate = autoUpdate;
+    m_projectionMatrix = glm::perspective(fovy, ratio, zNear, zFar);
 
-    if (m_dirty && m_autoUpdate)
-    {
-        update();
-    }
+    update();
+}
+
+void Camera::perspective(float fovy, const ivec2 &viewport, float zNear, float zFar)
+{
+    perspective(fovy, glm::max(float(viewport.x) / viewport.y, 1.0f), zNear, zFar);
 }
 
 void Camera::update() const
 {
-    if (!m_dirty)
-        return;
-
     invalidateMatrices();
-
-    m_dirty = false;
 
     const_cast<Camera*>(this)->changed();
 }
 
-const vec3 & Camera::eye() const
-{
-    return m_eye;
-}
-
-void Camera::setEye(const vec3 & eye)
-{
-    if (eye == m_eye)
-        return;
-
-    m_eye = eye;
-    dirty();
-}
-
-const vec3 & Camera::center() const
-{
-    return m_center;
-}
-
-void Camera::setCenter(const vec3 & center)
-{
-    if (center == m_center)
-        return;
-
-    m_center = center;
-    dirty();
-}
-
-const vec3 & Camera::up() const
-{
-    return m_up;
-}
-
-void Camera::setUp(const vec3 & up)
-{
-    if (up == m_up)
-        return;
-
-    m_up = up;
-    dirty();
-}
-
-float Camera::zNear() const
-{
-    return m_zNear;
-}
-
-void Camera::setZNear(const float zNear)
-{
-    if (std::abs(zNear - m_zNear) < std::numeric_limits<float>::epsilon())
-        return;
-
-    m_zNear = zNear;
-    assert(m_zNear > 0.0);
-
-    dirty();
-}
-
-float Camera::zFar() const
-{
-    return m_zFar;
-}
-
-void Camera::setZFar(const float zFar)
-{
-    if (std::abs(zFar - m_zFar) < std::numeric_limits<float>::epsilon())
-        return;
-
-    m_zFar = zFar;
-    assert(m_zFar > m_zNear);
-
-    dirty();
-}
-
-float Camera::fovy() const
-{
-    return m_fovy;
-}
-
-void Camera::setFovy(const float fovy)
-{
-    if (std::abs(fovy - m_fovy) < std::numeric_limits<float>::epsilon())
-        return;
-
-    m_fovy = fovy;
-    assert(m_fovy > 0.0);
-
-    dirty();
-}
-
-float Camera::aspectRatio() const
-{
-    return m_aspect;
-}
-
-void Camera::setAspectRatio(float ratio)
-{
-    m_aspect = ratio;
-
-    dirty();
-}
-
-void Camera::setAspectRatio(const ivec2 & viewport)
-{
-    m_aspect = static_cast<float>(viewport.x) / max(static_cast<float>(viewport.y), 1.f);
-
-    dirty();
-}
-
 const mat4 & Camera::viewMatrix() const
 {
-    if (m_dirty)
-        update();
-
-    if (!m_viewMatrix.isValid())
-        m_viewMatrix.setValue(lookAt(m_eye, m_center, m_up));
-
-    return m_viewMatrix.value();
+    return m_viewMatrix;
 }
 
 const mat4 & Camera::projectionMatrix() const
 {
-    if (m_dirty)
-        update();
-
-    if (!m_projectionMatrix.isValid())
-        m_projectionMatrix.setValue(perspective(m_fovy, m_aspect, m_zNear, m_zFar));
-
-    return m_projectionMatrix.value();
+    return m_projectionMatrix;
 }
 
 const mat4 & Camera::viewProjectionMatrix() const
 {
-    if (m_dirty)
-        update();
-
     if (!m_viewProjectionMatrix.isValid())
         m_viewProjectionMatrix.setValue(projectionMatrix() * viewMatrix());
     
@@ -200,9 +69,6 @@ const mat4 & Camera::viewProjectionMatrix() const
 
 const mat4 & Camera::viewInvertedMatrix() const
 {
-    if (m_dirty)
-        update();
-
     if (!m_viewInvertedMatrix.isValid())
         m_viewInvertedMatrix.setValue(inverse(viewMatrix()));
 
@@ -211,9 +77,6 @@ const mat4 & Camera::viewInvertedMatrix() const
 
 const mat4 & Camera::projectionInvertedMatrix() const
 {
-    if (m_dirty)
-        update();
-
     if (!m_projectionInvertedMatrix.isValid())
         m_projectionInvertedMatrix.setValue(inverse(projectionMatrix()));
 
@@ -222,9 +85,6 @@ const mat4 & Camera::projectionInvertedMatrix() const
 
 const mat4 & Camera::viewProjectionInvertedMatrix() const
 {
-    if (m_dirty)
-        update();
-
     if (!m_viewProjectionInvertedMatrix.isValid())
         m_viewProjectionInvertedMatrix.setValue(inverse(viewProjectionMatrix()));
 
@@ -233,13 +93,17 @@ const mat4 & Camera::viewProjectionInvertedMatrix() const
 
 const mat3 & Camera::normalMatrix() const
 {
-    if (m_dirty)
-        update();
-
     if (!m_normalMatrix.isValid())
         m_normalMatrix.setValue(inverseTranspose(mat3(viewMatrix())));
 
     return m_normalMatrix.value();
+}
+
+glm::vec3 Camera::eyeFromViewMatrix() const
+{
+    const auto eye = viewInvertedMatrix() * glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+
+    return glm::vec3(eye) / eye.w;
 }
 
 void Camera::changed()
@@ -247,19 +111,9 @@ void Camera::changed()
     invalidated();
 }
 
-void Camera::dirty(bool update)
-{
-    m_dirty = true;
-
-    if (update || m_autoUpdate)
-        this->update();
-}
-
 void Camera::invalidateMatrices() const
 {
-    m_viewMatrix.invalidate();
     m_viewInvertedMatrix.invalidate();
-    m_projectionMatrix.invalidate();
     m_projectionInvertedMatrix.invalidate();
     m_viewProjectionMatrix.invalidate();
     m_viewProjectionInvertedMatrix.invalidate();

--- a/source/gloperate/source/rendering/Camera.cpp
+++ b/source/gloperate/source/rendering/Camera.cpp
@@ -38,9 +38,9 @@ void Camera::perspective(float fovy, const ivec2 &viewport, float zNear, float z
     setProjectionMatrix(glm::perspective(fovy, glm::max(float(viewport.x) / viewport.y, 1.0f), zNear, zFar));
 }
 
-void Camera::ortho(float left, float right, float top, float bottom, float zNear, float zFar)
+void Camera::ortho(float left, float right, float bottom, float top, float zNear, float zFar)
 {
-    setProjectionMatrix(glm::ortho(left, right, bottom, bottom, zNear, zFar));
+    setProjectionMatrix(glm::ortho(left, right, bottom, top, zNear, zFar));
 }
 
 void Camera::ortho(float fovy, float aspect, float zNear, float zFar)

--- a/source/gloperate/source/stages/navigation/TrackballStage.cpp
+++ b/source/gloperate/source/stages/navigation/TrackballStage.cpp
@@ -96,12 +96,11 @@ void TrackballStage::onEvent(InputEvent * event)
 
 void TrackballStage::onProcess()
 {
-    m_camera->setAspectRatio(viewport->z / viewport->w);
-
     auto mat = glm::yawPitchRoll(glm::radians(*defaultYaw + m_yaw), glm::radians(*defaultPitch + m_pitch), 0.f);
     glm::vec4 rotatedCameraPosition = mat * glm::vec4(0.f, 0.f, 3.f * *defaultZoom * m_zoom, 1.f);
 
-    m_camera->setEye(glm::vec3(rotatedCameraPosition) / rotatedCameraPosition.w);
+    m_camera->lookAt(glm::vec3(rotatedCameraPosition) / rotatedCameraPosition.w, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+    m_camera->perspective(glm::radians(40.0f), glm::ivec2(viewport->z, viewport->w), 0.1f, 64.0f);
 
     camera.setValue(m_camera.get());
 }


### PR DESCRIPTION
This PR proposes changes to the current `Camera` class.
High-level summary of changes:
 * Reduce interface to represent a collection of space-transformations (world-to-view: view matrix; view-to-ndc: projection matrix)
 * Add convenience functions to allow configuration of standard camera models, directly mapping to the `glm` implementations
 * Adapt all uses within the examples