### PR TITLE
ClearStage: support glm vec4's

### DIFF
--- a/source/gloperate/include/gloperate/stages/base/ClearStage.h
+++ b/source/gloperate/include/gloperate/stages/base/ClearStage.h
@@ -55,7 +55,7 @@ public:
     *  @brief
     *    The list of supported types for framebuffer clearing
     */
-    using SupportedClearValueTypes = cppassist::TypeList<int, float, std::pair<float, int>, Color>;
+    using SupportedClearValueTypes = cppassist::TypeList<int, float, std::pair<float, int>, Color, glm::vec4, glm::ivec4, glm::uvec4>;
 
 
 public:

--- a/source/gloperate/source/stages/base/ClearStage.cpp
+++ b/source/gloperate/source/stages/base/ClearStage.cpp
@@ -305,7 +305,7 @@ void ClearStage::reprocessInputs()
         // Find next input that defines a clear value
         skipUntil(clearValueIt, m_inputs.end(), [] (AbstractSlot * input)
         {
-            return input->isOfAnyType<Color, float, int, std::pair<float, int>>();
+            return input->isOfAnyType<Color, float, int, std::pair<float, int>, glm::vec4, glm::ivec4, glm::uvec4>();
         });
 
         // Find next input that defines a render target


### PR DESCRIPTION
These are necessary to clear F|I|UI attachments.